### PR TITLE
fix scan iter command issued to different replicas

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -141,3 +141,4 @@ unicode
 url
 virtualenv
 www
+yaml

--- a/CHANGES
+++ b/CHANGES
@@ -65,6 +65,7 @@
     * Add `sum` to DUPLICATE_POLICY documentation of `TS.CREATE`, `TS.ADD` and `TS.ALTER`
     * Prevent async ClusterPipeline instances from becoming "false-y" in case of empty command stack (#3061)
     * Close Unix sockets if the connection attempt fails. This prevents `ResourceWarning`s. (#3314)
+    * Close SSL sockets if the connection attempt fails, or if validations fail. (#3317)
 
 * 4.1.3 (Feb 8, 2022)
   * Fix flushdb and flushall (#1926)

--- a/CHANGES
+++ b/CHANGES
@@ -64,6 +64,7 @@
     * Make `ClusterCommandsProtocol` an actual Protocol
     * Add `sum` to DUPLICATE_POLICY documentation of `TS.CREATE`, `TS.ADD` and `TS.ALTER`
     * Prevent async ClusterPipeline instances from becoming "false-y" in case of empty command stack (#3061)
+    * Close Unix sockets if the connection attempt fails. This prevents `ResourceWarning`s. (#3314)
 
 * 4.1.3 (Feb 8, 2022)
   * Fix flushdb and flushall (#1926)

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,8 +1,8 @@
 black==24.3.0
 cachetools
 click==8.0.4
-flake8-isort==6.0.0
-flake8==5.0.4
+flake8-isort
+flake8
 flynt~=0.69.0
 invoke==2.2.0
 mock

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,7 +128,6 @@ html_theme = "furo"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "display_version": True,
     "footer_icons": [
         {
             "name": "GitHub",

--- a/docs/connections.rst
+++ b/docs/connections.rst
@@ -55,7 +55,7 @@ ClusterNode
 Async Client
 ************
 
-See complete example: `here <examples/asyncio_examples.html>`_
+See complete example: `here <examples/asyncio_examples.html>`__
 
 This client is used for communicating with Redis, asynchronously.
 
@@ -88,7 +88,7 @@ ClusterPipeline (Async)
 Connection
 **********
 
-See complete example: `here <examples/connection_examples.html>`_
+See complete example: `here <examples/connection_examples.html>`__
 
 Connection
 ==========
@@ -104,7 +104,7 @@ Connection (Async)
 Connection Pools
 ****************
 
-See complete example: `here <examples/connection_examples.html>`_
+See complete example: `here <examples/connection_examples.html>`__
 
 ConnectionPool
 ==============

--- a/docs/opentelemetry.rst
+++ b/docs/opentelemetry.rst
@@ -4,7 +4,7 @@ Integrating OpenTelemetry
 What is OpenTelemetry?
 ----------------------
 
-`OpenTelemetry <https://opentelemetry.io>`_ is an open-source observability framework for traces, metrics, and logs. It is a merger of OpenCensus and OpenTracing projects hosted by Cloud Native Computing Foundation.
+`OpenTelemetry <https://opentelemetry.io>`__ is an open-source observability framework for traces, metrics, and logs. It is a merger of OpenCensus and OpenTracing projects hosted by Cloud Native Computing Foundation.
 
 OpenTelemetry allows developers to collect and export telemetry data in a vendor agnostic way. With OpenTelemetry, you can instrument your application once and then add or change vendors without changing the instrumentation, for example, here is a list of `popular DataDog competitors <https://uptrace.dev/get/compare/datadog-competitors.html>`_ that support OpenTelemetry.
 
@@ -61,7 +61,7 @@ Once the code is patched, you can use redis-py as usually:
 OpenTelemetry API
 -----------------
 
-`OpenTelemetry <https://uptrace.dev/opentelemetry/>`_ API is a programming interface that you can use to instrument code and collect telemetry data such as traces, metrics, and logs.
+`OpenTelemetry API <https://uptrace.dev/opentelemetry/>`__ is a programming interface that you can use to instrument code and collect telemetry data such as traces, metrics, and logs.
 
 You can use OpenTelemetry API to measure important operations:
 
@@ -125,7 +125,7 @@ Alerting and notifications
 
 Uptrace also allows you to monitor `OpenTelemetry metrics <https://uptrace.dev/opentelemetry/metrics.html>`_ using alerting rules. For example, the following monitor uses the group by node expression to create an alert whenever an individual Redis shard is down:
 
-.. code-block:: python
+.. code-block:: yaml
 
    monitors:
      - name: Redis shard is down
@@ -142,7 +142,7 @@ Uptrace also allows you to monitor `OpenTelemetry metrics <https://uptrace.dev/o
 
 You can also create queries with more complex expressions. For example, the following rule creates an alert when the keyspace hit rate is lower than 75%:
 
-.. code-block:: python
+.. code-block:: yaml
 
    monitors:
      - name: Redis read hit rate < 75%

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,6 @@ markers =
     experimental: run only experimental tests
 asyncio_mode = auto
 timeout = 30
+filterwarnings =
+    always
+    ignore:RedisGraph support is deprecated as of Redis Stack 7.2:DeprecationWarning

--- a/redis/_parsers/helpers.py
+++ b/redis/_parsers/helpers.py
@@ -507,7 +507,7 @@ def parse_geosearch_generic(response, **options):
     except KeyError:  # it means the command was sent via execute_command
         return response
 
-    if type(response) != list:
+    if not isinstance(response, list):
         response_list = [response]
     else:
         response_list = response

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -652,7 +652,7 @@ class Redis(
             if not self.connection:
                 await pool.release(conn)
                 if "ITER" in command_name.upper():
-                    pool.cleanup(iter_req_id=options.get("_iter_req_id", None))
+                    pool.cleanup(iter_req_id=options.get("iter_req_id", None))
 
     async def parse_response(
         self, connection: Connection, command_name: Union[str, bytes], **options

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -651,6 +651,8 @@ class Redis(
         finally:
             if not self.connection:
                 await pool.release(conn)
+                if "ITER" in command_name.upper():
+                    pool.cleanup_scan(iter_req_id=options.get("_iter_req_id", None))
 
     async def parse_response(
         self, connection: Connection, command_name: Union[str, bytes], **options

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -651,7 +651,9 @@ class Redis(
         finally:
             if not self.connection:
                 await pool.release(conn)
-                if "ITER" in command_name.upper():
+                # Do additional cleanup if this is part of a SCAN ITER family command.
+                # It's possible that this is just a pure SCAN family command though.
+                if "SCAN" in command_name.upper():
                     pool.cleanup(iter_req_id=options.get("iter_req_id", None))
 
     async def parse_response(

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -652,7 +652,7 @@ class Redis(
             if not self.connection:
                 await pool.release(conn)
                 if "ITER" in command_name.upper():
-                    pool.cleanup_scan(iter_req_id=options.get("_iter_req_id", None))
+                    pool.cleanup(iter_req_id=options.get("_iter_req_id", None))
 
     async def parse_response(
         self, connection: Connection, command_name: Union[str, bytes], **options

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1057,12 +1057,15 @@ class ConnectionPool:
     ``connection_class``.
     """
 
-    @abstractmethod
     def cleanup(self, **options):
         """
         Additional cleanup operations that the connection pool might
-        need to do after a SCAN ITER family command is executed
+        need to do after a SCAN ITER family command is executed.
+
+        See SentinelManagedConnection for an example cleanup operation that
+        might need to be done.
         """
+        pass
 
     @classmethod
     def from_url(cls: Type[_CP], url: str, **kwargs) -> _CP:

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1131,7 +1131,7 @@ class ConnectionPool:
 
         self._available_connections: ConnectionsIndexer = ConnectionsIndexer()
         self._in_use_connections: Set[AbstractConnection] = set()
-        self._index_available_connections= index_available_connections
+        self._index_available_connections = index_available_connections
         self.encoder_class = self.connection_kwargs.get("encoder_class", Encoder)
 
     def __repr__(self):

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -38,7 +38,7 @@ else:
 
 from redis.asyncio.retry import Retry
 from redis.backoff import NoBackoff
-from redis.connection import DEFAULT_RESP_VERSION, ConnectionsIndexer
+from redis.connection import DEFAULT_RESP_VERSION
 from redis.credentials import CredentialProvider, UsernamePasswordCredentialProvider
 from redis.exceptions import (
     AuthenticationError,
@@ -1118,7 +1118,6 @@ class ConnectionPool:
         self,
         connection_class: Type[AbstractConnection] = Connection,
         max_connections: Optional[int] = None,
-        index_available_connections: bool = False,
         **connection_kwargs,
     ):
         max_connections = max_connections or 2**31
@@ -1129,11 +1128,14 @@ class ConnectionPool:
         self.connection_kwargs = connection_kwargs
         self.max_connections = max_connections
 
+<<<<<<< HEAD
         self._available_connections: ConnectionsIndexer = (
             ConnectionsIndexer() if index_available_connections else []
         )
+=======
+        self._available_connections = self.reset_available_connections()
+>>>>>>> bafbc03 (polymorphism for reset available connections instead)
         self._in_use_connections: Set[AbstractConnection] = set()
-        self._index_available_connections = index_available_connections
         self.encoder_class = self.connection_kwargs.get("encoder_class", Encoder)
 
     def __repr__(self):
@@ -1143,10 +1145,11 @@ class ConnectionPool:
         )
 
     def reset(self):
-        self._available_connections: ConnectionsIndexer | list = (
-            ConnectionsIndexer() if self._index_available_connections else []
-        )
+        self._available_connections = self.reset_available_connections()
         self._in_use_connections = weakref.WeakSet()
+
+    def reset_available_connections(self):
+        return []
 
     def can_get_connection(self) -> bool:
         """Return True if a connection can be retrieved from the pool."""

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1118,6 +1118,7 @@ class ConnectionPool:
         self,
         connection_class: Type[AbstractConnection] = Connection,
         max_connections: Optional[int] = None,
+        index_available_connections: bool = False,
         **connection_kwargs,
     ):
         max_connections = max_connections or 2**31
@@ -1130,6 +1131,7 @@ class ConnectionPool:
 
         self._available_connections: ConnectionsIndexer = ConnectionsIndexer()
         self._in_use_connections: Set[AbstractConnection] = set()
+        self._index_available_connections= index_available_connections
         self.encoder_class = self.connection_kwargs.get("encoder_class", Encoder)
 
     def __repr__(self):
@@ -1139,7 +1141,9 @@ class ConnectionPool:
         )
 
     def reset(self):
-        self._available_connections = []
+        self._available_connections: ConnectionsIndexer | list = (
+            ConnectionsIndexer() if self._index_available_connections else []
+        )
         self._in_use_connections = weakref.WeakSet()
 
     def can_get_connection(self) -> bool:

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1059,9 +1059,7 @@ class ConnectionPool:
 
     def cleanup(self, **options):
         """
-        Additional cleanup operations that the connection pool might
-        need to do after a SCAN ITER family command is executed.
-
+        Additional cleanup operations that the connection pool might need to do.
         See SentinelManagedConnection for an example cleanup operation that
         might need to be done.
         """

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1128,13 +1128,7 @@ class ConnectionPool:
         self.connection_kwargs = connection_kwargs
         self.max_connections = max_connections
 
-<<<<<<< HEAD
-        self._available_connections: ConnectionsIndexer = (
-            ConnectionsIndexer() if index_available_connections else []
-        )
-=======
         self._available_connections = self.reset_available_connections()
->>>>>>> bafbc03 (polymorphism for reset available connections instead)
         self._in_use_connections: Set[AbstractConnection] = set()
         self.encoder_class = self.connection_kwargs.get("encoder_class", Encoder)
 

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1129,7 +1129,9 @@ class ConnectionPool:
         self.connection_kwargs = connection_kwargs
         self.max_connections = max_connections
 
-        self._available_connections: ConnectionsIndexer = ConnectionsIndexer()
+        self._available_connections: ConnectionsIndexer = (
+            ConnectionsIndexer() if index_available_connections else []
+        )
         self._in_use_connections: Set[AbstractConnection] = set()
         self._index_available_connections = index_available_connections
         self.encoder_class = self.connection_kwargs.get("encoder_class", Encoder)

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1058,7 +1058,7 @@ class ConnectionPool:
     """
 
     @abstractmethod
-    def cleanup_scan(self, **options):
+    def cleanup(self, **options):
         """
         Additional cleanup operations that the connection pool might
         need to do after a SCAN ITER family command is executed
@@ -1332,5 +1332,5 @@ class BlockingConnectionPool(ConnectionPool):
             await super().release(connection)
             self._condition.notify()
 
-    def cleanup_scan(self, **options):
+    def cleanup(self, **options):
         pass

--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -21,6 +21,7 @@ from redis.asyncio.connection import (
 )
 from redis.commands import AsyncSentinelCommands
 from redis.exceptions import ConnectionError, ReadOnlyError, ResponseError, TimeoutError
+from redis.sentinel import ConnectionsIndexer
 from redis.utils import str_if_bytes
 
 
@@ -162,6 +163,9 @@ class SentinelConnectionPool(ConnectionPool):
         super().reset()
         self.master_address = None
         self.slave_rr_counter = None
+
+    def reset_available_connections(self):
+        return ConnectionsIndexer()
 
     def owns_connection(self, connection: Connection):
         check = not self.is_master or (

--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -234,9 +234,7 @@ class SentinelConnectionPool(ConnectionPool):
         """
         Remove the SCAN ITER family command's request id from the dictionary
         """
-        self._iter_req_id_to_replica_address.pop(
-            options.get("iter_req_id", None), None
-        )
+        self._iter_req_id_to_replica_address.pop(options.get("iter_req_id", None), None)
 
     async def get_connection(
         self, command_name: str, *keys: Any, **options: Any

--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -71,10 +71,10 @@ class SentinelManagedConnection(Connection):
         # If address is fixed, it means that the connection
         # is not rotating to the next slave (if the connection pool is in replica mode)
         if self._is_address_fixed:
-            self.connect_to(self.host, self.port)
+            await self.connect_to((self.host, self.port))
             return
         await self._connect_to_sentinel()
-    
+
     async def _connect_to_sentinel(self):
         # If same_server is False, connnect to master in master mode
         # and rotate to the next slave in slave mode

--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -257,7 +257,7 @@ class SentinelConnectionPool(ConnectionPool):
             # This will connect to the host and port of the replica
             else:
                 await connection.connect_to_address(server_host, server_port)
-            self.ensure_connection(connection)
+            await self.ensure_connection(connection)
         except BaseException:
             # Release the connection back to the pool so that we don't
             # leak it

--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -73,6 +73,9 @@ class SentinelManagedConnection(Connection):
         if self._is_address_fixed:
             self.connect_to(self.host, self.port)
             return
+        await self._connect_to_sentinel()
+    
+    async def _connect_to_sentinel(self):
         # If same_server is False, connnect to master in master mode
         # and rotate to the next slave in slave mode
         if self.connection_pool.is_master:

--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -198,23 +198,21 @@ class SentinelConnectionPool(ConnectionPool):
     ) -> SentinelManagedConnection:
         """
         Get a connection from the pool.
-        `xxx_scan_iter` commands needs to be handled specially.
+        'xxxscan_iter' ('scan_iter', 'hscan_iter', 'sscan_iter', 'zscan_iter')
+        commands needs to be handled specially.
         If the client is created using a connection pool, in replica mode,
-        all `scan` command-equivalent of the `xxx_scan_iter` commands needs
+        all 'scan' command-equivalent of the 'xxx_scan_iter' commands needs
         to be issued to the same Redis replica.
 
         The way each server positions each key is different with one another,
-        and the cursor acts as the 'offset' of the scan.
-        Hence, all scans coming from a single xxx_scan_iter_channel command
+        and the cursor acts as the offset of the scan.
+        Hence, all scans coming from a single 'xxx_scan_iter_channel' command
         should go to the same replica.
         """
-        # If not an iter command or in master mode, call super()
-        # No custom logic for master, because there's only 1 master.
-        # The bug is only when Redis has the possibility to connect to multiple replicas
+        # If not an iter command or in master mode, call superclass' implementation
         if not (iter_req_id := options.get("_iter_req_id", None)) or self.is_master:
             return await super().get_connection(command_name, *keys, **options)
 
-        # Check if this iter request has already been directed to a particular server
         # Check if this iter request has already been directed to a particular server
         (
             server_host,
@@ -232,8 +230,8 @@ class SentinelConnectionPool(ConnectionPool):
         else:
             # Check from the available connections, if any of the connection
             # is connected to the host and port that we want
-            # If yes, use that connection
             for available_connection in self._available_connections.copy():
+                # if yes, use that connection
                 if (
                     available_connection.host == server_host
                     and available_connection.port == server_port
@@ -247,22 +245,20 @@ class SentinelConnectionPool(ConnectionPool):
         assert connection
         self._in_use_connections.add(connection)
         try:
-            # ensure this connection is connected to Redis
-            # If this is the first scan request,
-            # just call the SentinelManagedConnection.connect()
-            # This will call rotate_slaves
-            # and connect to a random replica
+            # Ensure this connection is connected to Redis
+            # If this is the first scan request, it will
+            # call rotate_slaves and connect to a random replica
             if server_port is None or server_port is None:
                 await connection.connect()
             # If this is not the first scan request,
-            # connect to the particular address and port
+            # connect to the previous replica.
+            # This will connect to the host and port of the replica
             else:
-                # This will connect to the host and port that we've specified above
                 await connection.connect_to_address(server_host, server_port)
-            # connections that the pool provides should be ready to send
-            # a command. if not, the connection was either returned to the
+            # Connections that the pool provides should be ready to send
+            # a command. If not, the connection was either returned to the
             # pool before all data has been read or the socket has been
-            # closed. either way, reconnect and verify everything is good.
+            # closed. Either way, reconnect and verify everything is good.
             try:
                 if await connection.can_read_destructive():
                     raise ConnectionError("Connection has data") from None
@@ -272,7 +268,7 @@ class SentinelConnectionPool(ConnectionPool):
                 if await connection.can_read_destructive():
                     raise ConnectionError("Connection not ready") from None
         except BaseException:
-            # release the connection back to the pool so that we don't
+            # Release the connection back to the pool so that we don't
             # leak it
             await self.release(connection)
             raise
@@ -281,7 +277,6 @@ class SentinelConnectionPool(ConnectionPool):
             connection.host,
             connection.port,
         )
-
         return connection
 
 

--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -230,7 +230,7 @@ class SentinelConnectionPool(ConnectionPool):
         Remove the SCAN ITER family command's request id from the dictionary
         """
         self._iter_req_id_to_replica_address.pop(
-            options.get("_iter_req_id", None), None
+            options.get("iter_req_id", None), None
         )
 
     async def get_connection(
@@ -250,7 +250,7 @@ class SentinelConnectionPool(ConnectionPool):
         should go to the same replica.
         """
         # If not an iter command or in master mode, call superclass' implementation
-        if not (iter_req_id := options.get("_iter_req_id", None)) or self.is_master:
+        if not (iter_req_id := options.get("iter_req_id", None)) or self.is_master:
             return await super().get_connection(command_name, *keys, **options)
 
         # Check if this iter request has already been directed to a particular server

--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -253,7 +253,6 @@ class SentinelConnectionPool(ConnectionPool):
         should go to the same replica.
         """
         # If not an iter command or in master mode, call superclass' implementation
-        breakpoint()
         if not (iter_req_id := options.get("iter_req_id", None)) or self.is_master:
             return await super().get_connection(command_name, *keys, **options)
 
@@ -293,9 +292,7 @@ class SentinelConnectionPool(ConnectionPool):
             # This will connect to the host and port of the replica
             else:
                 await connection.connect_to_address((server_host, server_port))
-            breakpoint()
             await self.ensure_connection_connected_to_address(connection)
-            breakpoint()
         except BaseException:
             # Release the connection back to the pool so that we don't
             # leak it

--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -253,6 +253,7 @@ class SentinelConnectionPool(ConnectionPool):
         should go to the same replica.
         """
         # If not an iter command or in master mode, call superclass' implementation
+        breakpoint()
         if not (iter_req_id := options.get("iter_req_id", None)) or self.is_master:
             return await super().get_connection(command_name, *keys, **options)
 
@@ -292,7 +293,9 @@ class SentinelConnectionPool(ConnectionPool):
             # This will connect to the host and port of the replica
             else:
                 await connection.connect_to_address((server_host, server_port))
+            breakpoint()
             await self.ensure_connection_connected_to_address(connection)
+            breakpoint()
         except BaseException:
             # Release the connection back to the pool so that we don't
             # leak it

--- a/redis/client.py
+++ b/redis/client.py
@@ -581,6 +581,9 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         finally:
             if not self.connection:
                 pool.release(conn)
+            if "SCAN" in command_name.upper():
+                breakpoint()
+                pool.cleanup(iter_req_id=options.get("_iter_req_id", None))
 
     def parse_response(self, connection, command_name, **options):
         """Parses a response from the Redis server"""

--- a/redis/client.py
+++ b/redis/client.py
@@ -582,7 +582,6 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
             if not self.connection:
                 pool.release(conn)
             if "SCAN" in command_name.upper():
-                breakpoint()
                 pool.cleanup(iter_req_id=options.get("_iter_req_id", None))
 
     def parse_response(self, connection, command_name, **options):
@@ -764,6 +763,7 @@ class PubSub:
         self.patterns = {}
         self.pending_unsubscribe_patterns = set()
         self.subscribed_event.clear()
+        self.connection_pool.cleanup(iter_req_id=options.get("_iter_req_id", None))
 
     def close(self) -> None:
         self.reset()

--- a/redis/client.py
+++ b/redis/client.py
@@ -581,8 +581,10 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         finally:
             if not self.connection:
                 pool.release(conn)
+            # Do additional cleanup if this is part of a SCAN ITER family command.
+            # It's possible that this is just a pure SCAN family command though.
             if "SCAN" in command_name.upper():
-                pool.cleanup(iter_req_id=options.get("_iter_req_id", None))
+                pool.cleanup(iter_req_id=options.get("iter_req_id", None))
 
     def parse_response(self, connection, command_name, **options):
         """Parses a response from the Redis server"""

--- a/redis/client.py
+++ b/redis/client.py
@@ -763,7 +763,6 @@ class PubSub:
         self.patterns = {}
         self.pending_unsubscribe_patterns = set()
         self.subscribed_event.clear()
-        self.connection_pool.cleanup(iter_req_id=options.get("_iter_req_id", None))
 
     def close(self) -> None:
         self.reset()

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -79,7 +79,7 @@ class ACLCommands(CommandsProtocol):
 
     def acl_deluser(self, *username: str, **kwargs) -> ResponseT:
         """
-        Delete the ACL for the specified ``username``s
+        Delete the ACL for the specified ``username``\\s
 
         For more information see https://redis.io/commands/acl-deluser
         """
@@ -227,9 +227,10 @@ class ACLCommands(CommandsProtocol):
                       must be prefixed with either a '+' to add the command permission
                       or a '-' to remove the command permission.
             keys: A list of key patterns to grant the user access to. Key patterns allow
-                  '*' to support wildcard matching. For example, '*' grants access to
-                  all keys while 'cache:*' grants access to all keys that are prefixed
-                  with 'cache:'. `keys` should not be prefixed with a '~'.
+                  ``'*'`` to support wildcard matching. For example, ``'*'`` grants
+                  access to all keys while ``'cache:*'`` grants access to all keys that
+                  are prefixed with ``cache:``.
+                  `keys` should not be prefixed with a ``'~'``.
             reset: Indicates whether the user should be fully reset prior to applying
                    the new ACL. Setting this to `True` will remove all existing
                    passwords, flags, and privileges from the user and then apply the
@@ -3366,7 +3367,7 @@ class SetCommands(CommandsProtocol):
         self, numkeys: int, keys: List[str], limit: int = 0
     ) -> Union[Awaitable[int], int]:
         """
-        Return the cardinality of the intersect of multiple sets specified by ``keys`.
+        Return the cardinality of the intersect of multiple sets specified by ``keys``.
 
         When LIMIT provided (defaults to 0 and means unlimited), if the intersection
         cardinality reaches limit partway through the computation, the algorithm will
@@ -3498,9 +3499,11 @@ class StreamCommands(CommandsProtocol):
     def xack(self, name: KeyT, groupname: GroupT, *ids: StreamIdT) -> ResponseT:
         """
         Acknowledges the successful processing of one or more messages.
-        name: name of the stream.
-        groupname: name of the consumer group.
-        *ids: message ids to acknowledge.
+
+        Args:
+            name: name of the stream.
+            groupname: name of the consumer group.
+            *ids: message ids to acknowledge.
 
         For more information see https://redis.io/commands/xack
         """
@@ -3696,8 +3699,10 @@ class StreamCommands(CommandsProtocol):
     def xdel(self, name: KeyT, *ids: StreamIdT) -> ResponseT:
         """
         Deletes one or more messages from a stream.
-        name: name of the stream.
-        *ids: message ids to delete.
+
+        Args:
+            name: name of the stream.
+            *ids: message ids to delete.
 
         For more information see https://redis.io/commands/xdel
         """
@@ -4265,7 +4270,7 @@ class SortedSetCommands(CommandsProtocol):
     ) -> Union[Awaitable[int], int]:
         """
         Return the cardinality of the intersect of multiple sorted sets
-        specified by ``keys`.
+        specified by ``keys``.
         When LIMIT provided (defaults to 0 and means unlimited), if the intersection
         cardinality reaches limit partway through the computation, the algorithm will
         exit and yield limit as the cardinality

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -3068,7 +3068,7 @@ class ScanCommands(CommandsProtocol):
             pieces.extend([b"MATCH", match])
         if count is not None:
             pieces.extend([b"COUNT", count])
-        return self.execute_command("SSCAN", *pieces,)
+        return self.execute_command("SSCAN", *pieces, **kwargs)
 
     def sscan_iter(
         self,
@@ -3293,11 +3293,7 @@ class AsyncScanCommands(ScanCommands):
         cursor = "0"
         while cursor != 0:
             cursor, data = await self.hscan(
-<<<<<<< HEAD
-                name, cursor=cursor, match=match, count=count, no_values=no_values
-=======
-                name, cursor=cursor, match=match, count=count, _iter_req_id=iter_req_id
->>>>>>> 39aaec6 (fix scan iter command issued to different replicas)
+                name, cursor=cursor, match=match, count=count, no_values=no_values, _iter_req_id=iter_req_id
             )
             if no_values:
                 for it in data:

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -1380,9 +1380,6 @@ class ManagementCommands(CommandsProtocol):
         )
 
 
-AsyncManagementCommands = ManagementCommands
-
-
 class AsyncManagementCommands(ManagementCommands):
     async def command_info(self, **kwargs) -> None:
         return super().command_info(**kwargs)

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -3293,7 +3293,12 @@ class AsyncScanCommands(ScanCommands):
         cursor = "0"
         while cursor != 0:
             cursor, data = await self.hscan(
-                name, cursor=cursor, match=match, count=count, no_values=no_values, _iter_req_id=iter_req_id
+                name,
+                cursor=cursor,
+                match=match,
+                count=count,
+                no_values=no_values,
+                _iter_req_id=iter_req_id,
             )
             if no_values:
                 for it in data:

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -3046,7 +3046,7 @@ class ScanCommands(CommandsProtocol):
                 match=match,
                 count=count,
                 _type=_type,
-                _iter_req_id=iter_req_id,
+                iter_req_id=iter_req_id,
                 **kwargs,
             )
             yield from data
@@ -3094,7 +3094,7 @@ class ScanCommands(CommandsProtocol):
         iter_req_id = uuid.uuid4()
         while cursor != 0:
             cursor, data = self.sscan(
-                name, cursor=cursor, match=match, count=count, _iter_req_id=iter_req_id
+                name, cursor=cursor, match=match, count=count, iter_req_id=iter_req_id
             )
             yield from data
 
@@ -3154,7 +3154,7 @@ class ScanCommands(CommandsProtocol):
                 match=match,
                 count=count,
                 no_values=no_values,
-                _iter_req_id=iter_req_id,
+                iter_req_id=iter_req_id,
             )
             if no_values:
                 yield from data
@@ -3216,7 +3216,7 @@ class ScanCommands(CommandsProtocol):
                 match=match,
                 count=count,
                 score_cast_func=score_cast_func,
-                _iter_req_id=iter_req_id,
+                iter_req_id=iter_req_id,
             )
             yield from data
 
@@ -3254,7 +3254,7 @@ class AsyncScanCommands(ScanCommands):
                 match=match,
                 count=count,
                 _type=_type,
-                _iter_req_id=iter_req_id,
+                iter_req_id=iter_req_id,
                 **kwargs,
             )
             for d in data:
@@ -3281,7 +3281,7 @@ class AsyncScanCommands(ScanCommands):
         cursor = "0"
         while cursor != 0:
             cursor, data = await self.sscan(
-                name, cursor=cursor, match=match, count=count, _iter_req_id=iter_req_id
+                name, cursor=cursor, match=match, count=count, iter_req_id=iter_req_id
             )
             for d in data:
                 yield d
@@ -3315,7 +3315,7 @@ class AsyncScanCommands(ScanCommands):
                 match=match,
                 count=count,
                 no_values=no_values,
-                _iter_req_id=iter_req_id,
+                iter_req_id=iter_req_id,
             )
             if no_values:
                 for it in data:
@@ -3353,7 +3353,7 @@ class AsyncScanCommands(ScanCommands):
                 match=match,
                 count=count,
                 score_cast_func=score_cast_func,
-                _iter_req_id=iter_req_id,
+                iter_req_id=iter_req_id,
             )
             for d in data:
                 yield d

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -3039,9 +3039,15 @@ class ScanCommands(CommandsProtocol):
             Additionally, Redis modules can expose other types as well.
         """
         cursor = "0"
+        iter_req_id = uuid.uuid4()
         while cursor != 0:
             cursor, data = self.scan(
-                cursor=cursor, match=match, count=count, _type=_type, **kwargs
+                cursor=cursor,
+                match=match,
+                count=count,
+                _type=_type,
+                _iter_req_id=iter_req_id,
+                **kwargs,
             )
             yield from data
 
@@ -3085,8 +3091,11 @@ class ScanCommands(CommandsProtocol):
         ``count`` allows for hint the minimum number of returns
         """
         cursor = "0"
+        iter_req_id = uuid.uuid4()
         while cursor != 0:
-            cursor, data = self.sscan(name, cursor=cursor, match=match, count=count)
+            cursor, data = self.sscan(
+                name, cursor=cursor, match=match, count=count, _iter_req_id=iter_req_id
+            )
             yield from data
 
     def hscan(
@@ -3137,9 +3146,15 @@ class ScanCommands(CommandsProtocol):
         ``no_values`` indicates to return only the keys, without values
         """
         cursor = "0"
+        iter_req_id = uuid.uuid4()
         while cursor != 0:
             cursor, data = self.hscan(
-                name, cursor=cursor, match=match, count=count, no_values=no_values
+                name,
+                cursor=cursor,
+                match=match,
+                count=count,
+                no_values=no_values,
+                _iter_req_id=iter_req_id,
             )
             if no_values:
                 yield from data
@@ -3193,6 +3208,7 @@ class ScanCommands(CommandsProtocol):
         ``score_cast_func`` a callable used to cast the score return value
         """
         cursor = "0"
+        iter_req_id = uuid.uuid4()
         while cursor != 0:
             cursor, data = self.zscan(
                 name,
@@ -3200,6 +3216,7 @@ class ScanCommands(CommandsProtocol):
                 match=match,
                 count=count,
                 score_cast_func=score_cast_func,
+                _iter_req_id=iter_req_id,
             )
             yield from data
 

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -1,8 +1,8 @@
 # from __future__ import annotations
 
-import uuid
 import datetime
 import hashlib
+import uuid
 import warnings
 from typing import (
     TYPE_CHECKING,
@@ -3226,12 +3226,19 @@ class AsyncScanCommands(ScanCommands):
             HASH, LIST, SET, STREAM, STRING, ZSET
             Additionally, Redis modules can expose other types as well.
         """
-        # DO NOT inline this statement to the scan call
-        iter_req_id = uuid.uuid4() # each iter command should have an ID to maintain connection to the same replica
+        #  DO NOT inline this statement to the scan call
+        #  Each iter command should have an ID to maintain
+        #  connection to the same replica
+        iter_req_id = uuid.uuid4()
         cursor = "0"
         while cursor != 0:
             cursor, data = await self.scan(
-                cursor=cursor, match=match, count=count, _type=_type, _iter_req_id=iter_req_id, **kwargs
+                cursor=cursor,
+                match=match,
+                count=count,
+                _type=_type,
+                _iter_req_id=iter_req_id,
+                **kwargs,
             )
             for d in data:
                 yield d
@@ -3250,8 +3257,10 @@ class AsyncScanCommands(ScanCommands):
 
         ``count`` allows for hint the minimum number of returns
         """
-        # DO NOT inline this statement to the scan call
-        iter_req_id = uuid.uuid4() # each iter command should have an ID to maintain connection to the same replica
+        #  DO NOT inline this statement to the scan call
+        #  Each iter command should have an ID to maintain
+        #  connection to the same replica
+        iter_req_id = uuid.uuid4()
         cursor = "0"
         while cursor != 0:
             cursor, data = await self.sscan(
@@ -3277,8 +3286,10 @@ class AsyncScanCommands(ScanCommands):
 
         ``no_values`` indicates to return only the keys, without values
         """
-        # DO NOT inline this statement to the scan call
-        iter_req_id = uuid.uuid4() # each iter command should have an ID to maintain connection to the same replica
+        #  DO NOT inline this statement to the scan call
+        #  Each iter command should have an ID to maintain
+        #  connection to the same replica
+        iter_req_id = uuid.uuid4()
         cursor = "0"
         while cursor != 0:
             cursor, data = await self.hscan(
@@ -3312,8 +3323,10 @@ class AsyncScanCommands(ScanCommands):
 
         ``score_cast_func`` a callable used to cast the score return value
         """
-        # DO NOT inline this statement to the scan call
-        iter_req_id = uuid.uuid4() # each iter command should have an ID to maintain connection to the same replica
+        #  DO NOT inline this statement to the scan call
+        #  Each iter command should have an ID to maintain
+        #  connection to the same replica
+        iter_req_id = uuid.uuid4()
         cursor = "0"
         while cursor != 0:
             cursor, data = await self.zscan(
@@ -3322,7 +3335,7 @@ class AsyncScanCommands(ScanCommands):
                 match=match,
                 count=count,
                 score_cast_func=score_cast_func,
-                _iter_req_id=iter_req_id
+                _iter_req_id=iter_req_id,
             )
             for d in data:
                 yield d

--- a/redis/commands/graph/commands.py
+++ b/redis/commands/graph/commands.py
@@ -155,7 +155,7 @@ class GraphCommands:
     def config(self, name, value=None, set=False):
         """
         Retrieve or update a RedisGraph configuration.
-        For more information see `https://redis.io/commands/graph.config-get/>`_. # noqa
+        For more information see `<https://redis.io/commands/graph.config-get/>`__.
 
         Args:
 

--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -337,30 +337,30 @@ class SearchCommands:
         """
         Add a single document to the index.
 
-        ### Parameters
+        Args:
 
-        - **doc_id**: the id of the saved document.
-        - **nosave**: if set to true, we just index the document, and don't
+            doc_id: the id of the saved document.
+            nosave: if set to true, we just index the document, and don't
                       save a copy of it. This means that searches will just
                       return ids.
-        - **score**: the document ranking, between 0.0 and 1.0
-        - **payload**: optional inner-index payload we can save for fast
-        i              access in scoring functions
-        - **replace**: if True, and the document already is in the index,
-        we perform an update and reindex the document
-        - **partial**: if True, the fields specified will be added to the
+            score: the document ranking, between 0.0 and 1.0
+            payload: optional inner-index payload we can save for fast
+                     access in scoring functions
+            replace: if True, and the document already is in the index,
+                     we perform an update and reindex the document
+            partial: if True, the fields specified will be added to the
                        existing document.
                        This has the added benefit that any fields specified
                        with `no_index`
                        will not be reindexed again. Implies `replace`
-        - **language**: Specify the language used for document tokenization.
-        - **no_create**: if True, the document is only updated and reindexed
+            language: Specify the language used for document tokenization.
+            no_create: if True, the document is only updated and reindexed
                          if it already exists.
                          If the document does not exist, an error will be
                          returned. Implies `replace`
-        - **fields** kwargs dictionary of the document fields to be saved
-                         and/or indexed.
-                     NOTE: Geo points shoule be encoded as strings of "lon,lat"
+            fields: kwargs dictionary of the document fields to be saved
+                    and/or indexed.
+                    NOTE: Geo points shoule be encoded as strings of "lon,lat"
         """  # noqa
         return self._add_document(
             doc_id,
@@ -627,13 +627,13 @@ class SearchCommands:
         """
         Issue a spellcheck query
 
-        ### Parameters
+        Args:
 
-        **query**: search query.
-        **distance***: the maximal Levenshtein distance for spelling
+            query: search query.
+            distance: the maximal Levenshtein distance for spelling
                        suggestions (default: 1, max: 4).
-        **include**: specifies an inclusion custom dictionary.
-        **exclude**: specifies an exclusion custom dictionary.
+            include: specifies an inclusion custom dictionary.
+            exclude: specifies an exclusion custom dictionary.
 
         For more information see `FT.SPELLCHECK <https://redis.io/commands/ft.spellcheck>`_.
         """  # noqa

--- a/redis/commands/timeseries/info.py
+++ b/redis/commands/timeseries/info.py
@@ -78,7 +78,7 @@ class TSInfo:
             self.chunk_size = response["chunkSize"]
         if "duplicatePolicy" in response:
             self.duplicate_policy = response["duplicatePolicy"]
-            if type(self.duplicate_policy) == bytes:
+            if isinstance(self.duplicate_policy, bytes):
                 self.duplicate_policy = self.duplicate_policy.decode()
 
     def get(self, item):

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -737,10 +737,10 @@ class Connection(AbstractConnection):
 
 class ConnectionsIndexer(Iterable):
     """
-    Data structure that simulates a list of available connections. 
+    Data structure that simulates a list of available connections.
     Instead of list, we keep 2 additional DS to support O(1) operations
     on all of the class' methods.
-    The first DS is indexed on the connection object's ID. 
+    The first DS is indexed on the connection object's ID.
     The second DS is indexed on the address (ip and port) of the connection.
     """
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1162,6 +1162,16 @@ class ConnectionPool:
             f"({repr(self.connection_class(**self.connection_kwargs))})>"
         )
 
+    def cleanup(self, **options):
+        """
+        Additional cleanup operations that the connection pool might
+        need to do after a SCAN ITER family command is executed.
+
+        See SentinelManagedConnection for an example cleanup operation that
+        might need to be done.
+        """
+        pass
+
     def reset(self) -> None:
         self._lock = threading.Lock()
         self._created_connections = 0

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1483,7 +1483,20 @@ class BlockingConnectionPool(ConnectionPool):
             connection = self.make_connection()
 
         try:
-            self.ensure_connection(connection)
+            # ensure this connection is connected to Redis
+            connection.connect()
+            # connections that the pool provides should be ready to send
+            # a command. if not, the connection was either returned to the
+            # pool before all data has been read or the socket has been
+            # closed. either way, reconnect and verify everything is good.
+            try:
+                if connection.can_read():
+                    raise ConnectionError("Connection has data")
+            except (ConnectionError, OSError):
+                connection.disconnect()
+                connection.connect()
+                if connection.can_read():
+                    raise ConnectionError("Connection not ready")
         except BaseException:
             # release the connection back to the pool so that we don't leak it
             self.release(connection)

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -819,7 +819,7 @@ class SSLConnection(Connection):
         sock = super()._connect()
         try:
             return self._wrap_socket_with_ssl(sock)
-        except OSError:
+        except (OSError, RedisError):
             sock.close()
             raise
 
@@ -854,7 +854,6 @@ class SSLConnection(Connection):
             context.minimum_version = self.ssl_min_version
         if self.ssl_ciphers:
             context.set_ciphers(self.ssl_ciphers)
-        sslsock = context.wrap_socket(sock, server_hostname=self.host)
         if self.ssl_validate_ocsp is True and CRYPTOGRAPHY_AVAILABLE is False:
             raise RedisError("cryptography is not installed.")
 
@@ -863,6 +862,8 @@ class SSLConnection(Connection):
                 "Either an OCSP staple or pure OCSP connection must be validated "
                 "- not both."
             )
+
+        sslsock = context.wrap_socket(sock, server_hostname=self.host)
 
         # validation for the stapled case
         if self.ssl_validate_ocsp_stapled:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1135,6 +1135,7 @@ class ConnectionPool:
         self,
         connection_class=Connection,
         max_connections: Optional[int] = None,
+        index_available_connections: bool = False,
         **connection_kwargs,
     ):
         max_connections = max_connections or 2**31
@@ -1154,6 +1155,7 @@ class ConnectionPool:
         # will notice the first thread already did the work and simply
         # release the lock.
         self._fork_lock = threading.Lock()
+        self._index_available_connections= index_available_connections
         self.reset()
 
     def __repr__(self) -> (str, str):
@@ -1175,7 +1177,9 @@ class ConnectionPool:
     def reset(self) -> None:
         self._lock = threading.Lock()
         self._created_connections = 0
-        self._available_connections = ConnectionsIndexer()
+        self._available_connections: ConnectionsIndexer | list = (
+            ConnectionsIndexer() if self._index_available_connections else []
+        )
         self._in_use_connections = set()
 
         # this must be the last operation in this method. while reset() is

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1155,7 +1155,7 @@ class ConnectionPool:
         # will notice the first thread already did the work and simply
         # release the lock.
         self._fork_lock = threading.Lock()
-        self._index_available_connections= index_available_connections
+        self._index_available_connections = index_available_connections
         self.reset()
 
     def __repr__(self) -> (str, str):

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -920,7 +920,12 @@ class UnixDomainSocketConnection(AbstractConnection):
         "Create a Unix domain socket connection"
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.settimeout(self.socket_connect_timeout)
-        sock.connect(self.path)
+        try:
+            sock.connect(self.path)
+        except OSError:
+            # Prevent ResourceWarnings for unclosed sockets.
+            sock.close()
+            raise
         sock.settimeout(self.socket_timeout)
         return sock
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1112,9 +1112,7 @@ class ConnectionPool:
 
     def cleanup(self, **options):
         """
-        Additional cleanup operations that the connection pool might
-        need to do after a SCAN ITER family command is executed.
-
+        Additional cleanup operations that the connection pool might need to do.
         See SentinelManagedConnection for an example cleanup operation that
         might need to be done.
         """

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -54,7 +54,6 @@ class SentinelManagedConnection(Connection):
         if self.connection_pool.is_master:
             self.connect_to(self.connection_pool.get_master_address())
         else:
-            breakpoint()
             for slave in self.connection_pool.rotate_slaves():
                 try:
                     return self.connect_to(slave)

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -263,7 +263,7 @@ class SentinelConnectionPool(ConnectionPool):
         """
         breakpoint()
         self._iter_req_id_to_replica_address.pop(
-            options.get("_iter_req_id", None), None
+            options.get("iter_req_id", None), None
         )
 
     def get_connection(
@@ -283,7 +283,7 @@ class SentinelConnectionPool(ConnectionPool):
         should go to the same replica.
         """
         # If not an iter command or in master mode, call superclass' implementation
-        if not (iter_req_id := options.get("_iter_req_id", None)) or self.is_master:
+        if not (iter_req_id := options.get("iter_req_id", None)) or self.is_master:
             return super().get_connection(command_name, *keys, **options)
 
         # Check if this iter request has already been directed to a particular server

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -54,6 +54,7 @@ class SentinelManagedConnection(Connection):
         if self.connection_pool.is_master:
             self.connect_to(self.connection_pool.get_master_address())
         else:
+            breakpoint()
             for slave in self.connection_pool.rotate_slaves():
                 try:
                     return self.connect_to(slave)

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -74,6 +74,14 @@ class SentinelManagedConnection(Connection):
             lambda error: None
         )
 
+    def connect_to_address(self, address):
+        """
+        Similar to connect, but instead of rotating to the next slave (if not in master mode),
+        it just connects to the address supplied.
+        """
+        self.host, self.port = address
+        return self.connect_to_same_address()
+
     def can_read_same_address(self, timeout=0):
         """Similar to can_read_same_address, but calls connect_to_same_address instead of connect"""
         sock = self._sock
@@ -312,7 +320,7 @@ class SentinelConnectionPool(ConnectionPool):
             # connect to the previous replica.
             # This will connect to the host and port of the replica
             else:
-                connection.connect_to_same_address()
+                connection.connect_to_address((server_host, server_port))
             self.ensure_connection_connected_to_address(connection)
         except BaseException:
             # Release the connection back to the pool so that we don't

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -261,7 +261,6 @@ class SentinelConnectionPool(ConnectionPool):
         """
         Remove the SCAN ITER family command's request id from the dictionary
         """
-        breakpoint()
         self._iter_req_id_to_replica_address.pop(
             options.get("iter_req_id", None), None
         )

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -261,6 +261,7 @@ class SentinelConnectionPool(ConnectionPool):
         """
         Remove the SCAN ITER family command's request id from the dictionary
         """
+        breakpoint()
         self._iter_req_id_to_replica_address.pop(
             options.get("_iter_req_id", None), None
         )

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -1,7 +1,7 @@
 import random
 import weakref
-from typing import Any, Iterable, Optional
 from collections import defaultdict
+from typing import Any, Iterable, Optional
 
 from redis.client import Redis
 from redis.commands import SentinelCommands

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -47,7 +47,7 @@ class SentinelManagedConnection(Connection):
         # If same_server is True, it means that the connection
         # is not rotating to the next slave (if the connection pool is not master)
         if same_address:
-            self.connect_to(self.host, self.port)
+            self.connect_to((self.host, self.port))
             return
         # If same_server is False, connnect to master in master mode  
         # and rotate to the next slave in slave mode
@@ -297,7 +297,7 @@ class SentinelConnectionPool(ConnectionPool):
                 host=server_host, port=server_port
             )
             # If not, make a new dummy connection object, and set its host and port
-            # to the one that we want later in the call to ``connect_to_address``
+            # to the one that we want later in the call to ``connect_to_same_address``
             if not connection:
                 connection = self.make_connection()
         assert connection
@@ -312,7 +312,7 @@ class SentinelConnectionPool(ConnectionPool):
             # connect to the previous replica.
             # This will connect to the host and port of the replica
             else:
-                connection.connect_to_address(server_host, server_port)
+                connection.connect_to_same_address()
             self.ensure_connection_connected_to_address(connection)
         except BaseException:
             # Release the connection back to the pool so that we don't

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -58,6 +58,9 @@ class SentinelManagedConnection(Connection):
         if self._is_address_fixed:
             self.connect_to((self.host, self.port))
             return
+        self._connect_to_sentinel()
+    
+    def _connect_to_sentinel(self):
         # If same_server is False, connnect to master in master mode
         # and rotate to the next slave in slave mode
         if self.connection_pool.is_master:

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -59,7 +59,7 @@ class SentinelManagedConnection(Connection):
             self.connect_to((self.host, self.port))
             return
         self._connect_to_sentinel()
-    
+
     def _connect_to_sentinel(self):
         # If same_server is False, connnect to master in master mode
         # and rotate to the next slave in slave mode

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -63,8 +63,7 @@ class SentinelManagedConnection(Connection):
 
     def connect(self):
         return self.retry.call_with_retry(
-            lambda: self._connect_retry(),
-            lambda error: None
+            lambda: self._connect_retry(), lambda error: None
         )
 
     def connect_to_same_address(self):
@@ -73,8 +72,7 @@ class SentinelManagedConnection(Connection):
         it just connects to the same address of the connection object.
         """
         return self.retry.call_with_retry(
-            lambda: self._connect_retry(same_address=True),
-            lambda error: None
+            lambda: self._connect_retry(same_address=True), lambda error: None
         )
 
     def connect_to_address(self, address):
@@ -269,9 +267,7 @@ class SentinelConnectionPool(ConnectionPool):
         """
         Remove the SCAN ITER family command's request id from the dictionary
         """
-        self._iter_req_id_to_replica_address.pop(
-            options.get("iter_req_id", None), None
-        )
+        self._iter_req_id_to_replica_address.pop(options.get("iter_req_id", None), None)
 
     def get_connection(
         self, command_name: str, *keys: Any, **options: Any

--- a/redis/typing.py
+++ b/redis/typing.py
@@ -54,10 +54,8 @@ ExceptionMappingT = Mapping[str, Union[Type[Exception], Mapping[str, Type[Except
 class CommandsProtocol(Protocol):
     connection_pool: Union["AsyncConnectionPool", "ConnectionPool"]
 
-    def execute_command(self, *args, **options): ...
+    def execute_command(self, *args, **options) -> ResponseT: ...
 
 
-class ClusterCommandsProtocol(CommandsProtocol, Protocol):
+class ClusterCommandsProtocol(CommandsProtocol):
     encoder: "Encoder"
-
-    def execute_command(self, *args, **options) -> Union[Any, Awaitable]: ...

--- a/tasks.py
+++ b/tasks.py
@@ -55,11 +55,11 @@ def standalone_tests(c, uvloop=False, protocol=2, profile=False):
     profile_arg = "--profile" if profile else ""
     if uvloop:
         run(
-            f"pytest {profile_arg} --protocol={protocol} --cov=./ --cov-report=xml:coverage_redis.xml -W always -m 'not onlycluster' --uvloop --junit-xml=standalone-uvloop-results.xml"
+            f"pytest {profile_arg} --protocol={protocol} --cov=./ --cov-report=xml:coverage_redis.xml -m 'not onlycluster' --uvloop --junit-xml=standalone-uvloop-results.xml"
         )
     else:
         run(
-            f"pytest {profile_arg} --protocol={protocol} --cov=./ --cov-report=xml:coverage_redis.xml -W always -m 'not onlycluster' --junit-xml=standalone-results.xml"
+            f"pytest {profile_arg} --protocol={protocol} --cov=./ --cov-report=xml:coverage_redis.xml -m 'not onlycluster' --junit-xml=standalone-results.xml"
         )
 
 
@@ -70,11 +70,11 @@ def cluster_tests(c, uvloop=False, protocol=2, profile=False):
     cluster_url = "redis://localhost:16379/0"
     if uvloop:
         run(
-            f"pytest {profile_arg} --protocol={protocol} --cov=./ --cov-report=xml:coverage_cluster.xml -W always -m 'not onlynoncluster and not redismod' --redis-url={cluster_url} --junit-xml=cluster-uvloop-results.xml --uvloop"
+            f"pytest {profile_arg} --protocol={protocol} --cov=./ --cov-report=xml:coverage_cluster.xml -m 'not onlynoncluster and not redismod' --redis-url={cluster_url} --junit-xml=cluster-uvloop-results.xml --uvloop"
         )
     else:
         run(
-            f"pytest  {profile_arg} --protocol={protocol} --cov=./ --cov-report=xml:coverage_clusteclient.xml -W always -m 'not onlynoncluster and not redismod' --redis-url={cluster_url} --junit-xml=cluster-results.xml"
+            f"pytest  {profile_arg} --protocol={protocol} --cov=./ --cov-report=xml:coverage_clusteclient.xml -m 'not onlynoncluster and not redismod' --redis-url={cluster_url} --junit-xml=cluster-results.xml"
         )
 
 

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -1402,8 +1402,8 @@ class TestRedisCommands:
         pairs = [k async for k in r.zscan_iter("a", match="a")]
         assert set(pairs) == {(b"a", 1)}
 
-    async def test_scan_iter_family_executes_commands_with_same_iter_req_id(self):
-        """Assert that all calls to execute_command receives the _iter_req_id kwarg"""
+    async def test_scan_iter_family_executes_commands_with_sameiter_req_id(self):
+        """Assert that all calls to execute_command receives the iter_req_id kwarg"""
         import uuid
 
         from redis.commands.core import AsyncScanCommands
@@ -1416,10 +1416,10 @@ class TestRedisCommands:
             uuid, "uuid4", return_value="uuid"
         ):
             [a async for a in AsyncScanCommands().scan_iter()]
-            mock_execute_command.assert_called_with("SCAN", "0", _iter_req_id="uuid")
+            mock_execute_command.assert_called_with("SCAN", "0", iter_req_id="uuid")
             [a async for a in AsyncScanCommands().sscan_iter("")]
             mock_execute_command.assert_called_with(
-                "SSCAN", "", "0", _iter_req_id="uuid"
+                "SSCAN", "", "0", iter_req_id="uuid"
             )
         with mock.patch.object(
             AsyncScanCommands, "execute_command", mock.AsyncMock(return_value=(0, {}))
@@ -1428,11 +1428,11 @@ class TestRedisCommands:
         ):
             [a async for a in AsyncScanCommands().hscan_iter("")]
             mock_execute_command.assert_called_with(
-                "HSCAN", "", "0", no_values=None, _iter_req_id="uuid"
+                "HSCAN", "", "0", no_values=None, iter_req_id="uuid"
             )
             [a async for a in AsyncScanCommands().zscan_iter("")]
             mock_execute_command.assert_called_with(
-                "ZSCAN", "", "0", score_cast_func=mock.ANY, _iter_req_id="uuid"
+                "ZSCAN", "", "0", score_cast_func=mock.ANY, iter_req_id="uuid"
             )
 
     # SET COMMANDS

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -1402,7 +1402,7 @@ class TestRedisCommands:
         pairs = [k async for k in r.zscan_iter("a", match="a")]
         assert set(pairs) == {(b"a", 1)}
 
-    async def test_scan_iter_family_executes_commands_with_same_iter_req_id():
+    async def test_scan_iter_family_executes_commands_with_same_iter_req_id(self):
         """Assert that all calls to execute_command receives the _iter_req_id kwarg"""
         import uuid
 

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -1402,7 +1402,7 @@ class TestRedisCommands:
         pairs = [k async for k in r.zscan_iter("a", match="a")]
         assert set(pairs) == {(b"a", 1)}
 
-    async def test_scan_iter_family_executes_commands_with_sameiter_req_id(self):
+    async def test_scan_iter_family_executes_commands_with_same_iter_req_id(self):
         """Assert that all calls to execute_command receives the iter_req_id kwarg"""
         import uuid
 

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -1402,6 +1402,39 @@ class TestRedisCommands:
         pairs = [k async for k in r.zscan_iter("a", match="a")]
         assert set(pairs) == {(b"a", 1)}
 
+    async def test_scan_iter_family_executes_commands_with_same_iter_req_id():
+        """Assert that all calls to execute_command receives the _iter_req_id kwarg"""
+        import uuid
+
+        from redis.commands.core import AsyncScanCommands
+
+        from .compat import mock
+
+        with mock.patch.object(
+            AsyncScanCommands, "execute_command", mock.AsyncMock(return_value=(0, []))
+        ) as mock_execute_command, mock.patch.object(
+            uuid, "uuid4", return_value="uuid"
+        ):
+            [a async for a in AsyncScanCommands().scan_iter()]
+            mock_execute_command.assert_called_with("SCAN", "0", _iter_req_id="uuid")
+            [a async for a in AsyncScanCommands().sscan_iter("")]
+            mock_execute_command.assert_called_with(
+                "SSCAN", "", "0", _iter_req_id="uuid"
+            )
+        with mock.patch.object(
+            AsyncScanCommands, "execute_command", mock.AsyncMock(return_value=(0, {}))
+        ) as mock_execute_command, mock.patch.object(
+            uuid, "uuid4", return_value="uuid"
+        ):
+            [a async for a in AsyncScanCommands().hscan_iter("")]
+            mock_execute_command.assert_called_with(
+                "HSCAN", "", "0", no_values=None, _iter_req_id="uuid"
+            )
+            [a async for a in AsyncScanCommands().zscan_iter("")]
+            mock_execute_command.assert_called_with(
+                "ZSCAN", "", "0", score_cast_func=mock.ANY, _iter_req_id="uuid"
+            )
+
     # SET COMMANDS
     async def test_sadd(self, r: redis.Redis):
         members = {b"1", b"2", b"3"}

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -647,7 +647,6 @@ class TestConnection:
         connection = redis.Redis.from_url("redis://localhost")
         pool = connection.connection_pool
 
-        print(repr(pool))
         assert re.match(
             r"< .*?([^\.]+) \( < .*?([^\.]+) \( (.+) \) > \) >", repr(pool), re.VERBOSE
         ).groups() == (

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -57,7 +57,7 @@ class TestRedisAutoReleaseConnectionPool:
         assert r2.connection_pool._in_use_connections == {new_conn}
         assert new_conn.is_connected
         assert len(r2.connection_pool._available_connections) == 1
-        assert r2.connection_pool.list(available_connections)[0].is_connected
+        assert r2.connection_list(pool._available_connections)[0].is_connected
 
     async def test_auto_release_override_true_manual_created_pool(self, r: redis.Redis):
         assert r.auto_close_connection_pool is True, "This is from the class fixture"
@@ -85,7 +85,7 @@ class TestRedisAutoReleaseConnectionPool:
         await r.aclose(close_connection_pool=False)
         assert not self.has_no_connected_connections(r.connection_pool)
         assert r.connection_pool._in_use_connections == {new_conn}
-        assert r.connection_pool.list(available_connections)[0].is_connected
+        assert r.connection_list(pool._available_connections)[0].is_connected
         assert self.get_total_connected_connections(r.connection_pool) == 2
 
 
@@ -579,7 +579,7 @@ class TestConnection:
             await bad_connection.info()
         pool = bad_connection.connection_pool
         assert len(pool._available_connections) == 1
-        assert not pool.list(available_connections)[0]._reader
+        assert not list(pool._available_connections)[0]._reader
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("2.8.8")
@@ -610,7 +610,7 @@ class TestConnection:
         pool = r.connection_pool
         assert not pipe.connection
         assert len(pool._available_connections) == 1
-        assert not pool.list(available_connections)[0]._reader
+        assert not list(pool._available_connections)[0]._reader
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("2.8.8")
@@ -627,7 +627,7 @@ class TestConnection:
         pool = r.connection_pool
         assert not pipe.connection
         assert len(pool._available_connections) == 1
-        assert not pool.list(available_connections)[0]._reader
+        assert not list(pool._available_connections)[0]._reader
 
     @skip_if_server_version_lt("2.8.8")
     @skip_if_redis_enterprise()

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -57,7 +57,7 @@ class TestRedisAutoReleaseConnectionPool:
         assert r2.connection_pool._in_use_connections == {new_conn}
         assert new_conn.is_connected
         assert len(r2.connection_pool._available_connections) == 1
-        assert r2.connection_pool._list(available_connections)[0].is_connected
+        assert r2.connection_pool.list(available_connections)[0].is_connected
 
     async def test_auto_release_override_true_manual_created_pool(self, r: redis.Redis):
         assert r.auto_close_connection_pool is True, "This is from the class fixture"
@@ -85,7 +85,7 @@ class TestRedisAutoReleaseConnectionPool:
         await r.aclose(close_connection_pool=False)
         assert not self.has_no_connected_connections(r.connection_pool)
         assert r.connection_pool._in_use_connections == {new_conn}
-        assert r.connection_pool._list(available_connections)[0].is_connected
+        assert r.connection_pool.list(available_connections)[0].is_connected
         assert self.get_total_connected_connections(r.connection_pool) == 2
 
 
@@ -579,7 +579,7 @@ class TestConnection:
             await bad_connection.info()
         pool = bad_connection.connection_pool
         assert len(pool._available_connections) == 1
-        assert not pool._list(available_connections)[0]._reader
+        assert not pool.list(available_connections)[0]._reader
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("2.8.8")
@@ -610,7 +610,7 @@ class TestConnection:
         pool = r.connection_pool
         assert not pipe.connection
         assert len(pool._available_connections) == 1
-        assert not pool._list(available_connections)[0]._reader
+        assert not pool.list(available_connections)[0]._reader
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("2.8.8")
@@ -627,7 +627,7 @@ class TestConnection:
         pool = r.connection_pool
         assert not pipe.connection
         assert len(pool._available_connections) == 1
-        assert not pool._list(available_connections)[0]._reader
+        assert not pool.list(available_connections)[0]._reader
 
     @skip_if_server_version_lt("2.8.8")
     @skip_if_redis_enterprise()

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -57,7 +57,7 @@ class TestRedisAutoReleaseConnectionPool:
         assert r2.connection_pool._in_use_connections == {new_conn}
         assert new_conn.is_connected
         assert len(r2.connection_pool._available_connections) == 1
-        assert r2.connection_list(pool._available_connections)[0].is_connected
+        assert list(r2.connection_pool._available_connections)[0].is_connected
 
     async def test_auto_release_override_true_manual_created_pool(self, r: redis.Redis):
         assert r.auto_close_connection_pool is True, "This is from the class fixture"
@@ -85,7 +85,7 @@ class TestRedisAutoReleaseConnectionPool:
         await r.aclose(close_connection_pool=False)
         assert not self.has_no_connected_connections(r.connection_pool)
         assert r.connection_pool._in_use_connections == {new_conn}
-        assert r.connection_list(pool._available_connections)[0].is_connected
+        assert list(r.connection_pool._available_connections)[0].is_connected
         assert self.get_total_connected_connections(r.connection_pool) == 2
 
 

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -94,6 +94,8 @@ class DummyConnection(Connection):
 
     def __init__(self, **kwargs):
         self.kwargs = kwargs
+        self.host = kwargs.get("host", None)
+        self.port = kwargs.get("port", None)
 
     def repr_pieces(self):
         return [("id", id(self)), ("kwargs", self.kwargs)]

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -57,7 +57,7 @@ class TestRedisAutoReleaseConnectionPool:
         assert r2.connection_pool._in_use_connections == {new_conn}
         assert new_conn.is_connected
         assert len(r2.connection_pool._available_connections) == 1
-        assert r2.connection_pool._available_connections[0].is_connected
+        assert r2.connection_pool._list(available_connections)[0].is_connected
 
     async def test_auto_release_override_true_manual_created_pool(self, r: redis.Redis):
         assert r.auto_close_connection_pool is True, "This is from the class fixture"
@@ -85,7 +85,7 @@ class TestRedisAutoReleaseConnectionPool:
         await r.aclose(close_connection_pool=False)
         assert not self.has_no_connected_connections(r.connection_pool)
         assert r.connection_pool._in_use_connections == {new_conn}
-        assert r.connection_pool._available_connections[0].is_connected
+        assert r.connection_pool._list(available_connections)[0].is_connected
         assert self.get_total_connected_connections(r.connection_pool) == 2
 
 
@@ -579,7 +579,7 @@ class TestConnection:
             await bad_connection.info()
         pool = bad_connection.connection_pool
         assert len(pool._available_connections) == 1
-        assert not pool._available_connections[0]._reader
+        assert not pool._list(available_connections)[0]._reader
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("2.8.8")
@@ -610,7 +610,7 @@ class TestConnection:
         pool = r.connection_pool
         assert not pipe.connection
         assert len(pool._available_connections) == 1
-        assert not pool._available_connections[0]._reader
+        assert not pool._list(available_connections)[0]._reader
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("2.8.8")
@@ -627,7 +627,7 @@ class TestConnection:
         pool = r.connection_pool
         assert not pipe.connection
         assert len(pool._available_connections) == 1
-        assert not pool._available_connections[0]._reader
+        assert not pool._list(available_connections)[0]._reader
 
     @skip_if_server_version_lt("2.8.8")
     @skip_if_redis_enterprise()

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+from itertools import chain
 
 import pytest
 import pytest_asyncio
@@ -35,7 +36,7 @@ class TestRedisAutoReleaseConnectionPool:
     def has_no_connected_connections(pool: redis.ConnectionPool):
         return not any(
             x.is_connected
-            for x in pool._available_connections + list(pool._in_use_connections)
+            for x in chain(pool._available_connections, pool._in_use_connections)
         )
 
     async def test_auto_disconnect_redis_created_pool(self, r: redis.Redis):

--- a/tests/test_asyncio/test_lock.py
+++ b/tests/test_asyncio/test_lock.py
@@ -237,4 +237,4 @@ class TestLockClassSelection:
                 pass
 
         lock = r.lock("foo", lock_class=MyLock)
-        assert type(lock) == MyLock
+        assert isinstance(lock, MyLock)

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -1,4 +1,5 @@
 import socket
+from typing import Tuple
 from unittest.mock import AsyncMock
 
 import pytest
@@ -71,7 +72,7 @@ class SentinelManagedConnectionMockForReplicaMode(SentinelManagedConnectionMock)
 
 
 class SentinelManagedConnectionMockForMasterMode(SentinelManagedConnectionMock):
-    async def connect_to(self, address: tuple[str, int]) -> None:
+    async def connect_to(self, address: Tuple[str, int]) -> None:
         """
         This simulates the behavior of connect_to when
         :py:class:`~redis.SentinelConnectionPool`

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -9,6 +9,7 @@ from redis.asyncio.sentinel import (
     SentinelManagedConnection,
 )
 from redis.backoff import NoBackoff
+from redis.utils import HIREDIS_AVAILABLE
 
 from .compat import mock
 

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -251,5 +251,6 @@ async def test_scan_iter_family_cleans_up(
 
     r = Redis(connection_pool=connection_pool_replica_mock)
 
-    [k async for k in r.scan_iter("a")]
-    assert not connection_pool_replica_mock.iter_req_id_to_replica_address
+    with mock.patch.object(r, "_send_command_parse_response", return_value=(0, [])):
+        [k async for k in r.scan_iter("a")]
+    assert not connection_pool_replica_mock._iter_req_id_to_replica_address

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -157,7 +157,7 @@ async def test_connects_to_same_conn_object_if_same_id_and_conn_released_replica
     )
 
 
-async def test_connects_to_diff_address_if_noiter_req_id_replica(
+async def test_connects_to_diff_address_if_no_iter_req_id_replica(
     connection_pool_replica_mock: SentinelConnectionPool,
 ) -> None:
     """
@@ -182,7 +182,7 @@ async def test_connects_to_diff_address_if_noiter_req_id_replica(
     )
 
 
-async def test_connects_to_same_address_if_sameiter_req_id_master(
+async def test_connects_to_same_address_if_same_iter_req_id_master(
     connection_pool_master_mock: SentinelConnectionPool,
 ) -> None:
     """
@@ -199,7 +199,7 @@ async def test_connects_to_same_address_if_sameiter_req_id_master(
     )
 
 
-async def test_connects_to_same_conn_object_if_sameiter_req_id_and_released_master(
+async def test_connects_to_same_conn_object_if_same_iter_req_id_and_released_master(
     connection_pool_master_mock: SentinelConnectionPool,
 ) -> None:
     """
@@ -218,7 +218,7 @@ async def test_connects_to_same_conn_object_if_sameiter_req_id_and_released_mast
     )
 
 
-async def test_connects_to_same_address_if_noiter_req_id_master(
+async def test_connects_to_same_address_if_no_iter_req_id_master(
     connection_pool_master_mock: SentinelConnectionPool,
 ) -> None:
     """

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -111,6 +111,7 @@ def same_address(
     )
 
 
+@pytest.mark.skipif(HIREDIS_AVAILABLE, reason="PythonParser only")
 async def test_connects_to_same_address_if_same_id_replica(
     connection_pool_replica_mock: SentinelConnectionPool,
 ) -> None:
@@ -128,6 +129,7 @@ async def test_connects_to_same_address_if_same_id_replica(
     )
 
 
+@pytest.mark.skipif(HIREDIS_AVAILABLE, reason="PythonParser only")
 async def test_connects_to_same_conn_object_if_same_id_and_conn_released_replica(
     connection_pool_replica_mock: SentinelConnectionPool,
 ) -> None:
@@ -148,6 +150,7 @@ async def test_connects_to_same_conn_object_if_same_id_and_conn_released_replica
     )
 
 
+@pytest.mark.skipif(HIREDIS_AVAILABLE, reason="PythonParser only")
 async def test_connects_to_diff_address_if_no_iter_req_id_replica(
     connection_pool_replica_mock: SentinelConnectionPool,
 ) -> None:
@@ -173,6 +176,7 @@ async def test_connects_to_diff_address_if_no_iter_req_id_replica(
     )
 
 
+@pytest.mark.skipif(HIREDIS_AVAILABLE, reason="PythonParser only")
 async def test_connects_to_same_address_if_same_iter_req_id_master(
     connection_pool_master_mock: SentinelConnectionPool,
 ) -> None:
@@ -190,6 +194,7 @@ async def test_connects_to_same_address_if_same_iter_req_id_master(
     )
 
 
+@pytest.mark.skipif(HIREDIS_AVAILABLE, reason="PythonParser only")
 async def test_connects_to_same_conn_object_if_same_iter_req_id_and_released_master(
     connection_pool_master_mock: SentinelConnectionPool,
 ) -> None:
@@ -209,6 +214,7 @@ async def test_connects_to_same_conn_object_if_same_iter_req_id_and_released_mas
     )
 
 
+@pytest.mark.skipif(HIREDIS_AVAILABLE, reason="PythonParser only")
 async def test_connects_to_same_address_if_no_iter_req_id_master(
     connection_pool_master_mock: SentinelConnectionPool,
 ) -> None:
@@ -234,6 +240,7 @@ async def test_connects_to_same_address_if_no_iter_req_id_master(
     )
 
 
+@pytest.mark.skipif(HIREDIS_AVAILABLE, reason="PythonParser only")
 async def test_scan_iter_family_cleans_up(
     connection_pool_replica_mock: SentinelConnectionPool,
 ):

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -1,10 +1,12 @@
 import socket
 from typing import Tuple
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, ANY
 
 import pytest
 import pytest_asyncio
+import uuid
 from redis.asyncio.retry import Retry
+from redis.commands.core import AsyncScanCommands
 from redis.asyncio.sentinel import (
     Sentinel,
     SentinelConnectionPool,
@@ -244,3 +246,25 @@ async def test_connects_to_same_address_if_no_iter_req_id_master(
         await connection_pool_master_mock.get_connection("ANY_COMMAND"),
         connection_for_req_1,
     )
+
+
+async def test_scan_iter_family_executes_commands_with_same_iter_req_id():
+    """Assert that all calls to execute_command receives the _iter_req_id kwarg"""
+    with mock.patch.object(
+        AsyncScanCommands,
+        "execute_command", 
+        AsyncMock(return_value=(0, []))
+    ) as mock_execute_command, mock.patch.object(uuid, "uuid4", return_value="uuid"):
+        [a async for a in AsyncScanCommands().scan_iter()]
+        mock_execute_command.assert_called_with('SCAN', '0', _iter_req_id="uuid")
+        [a async for a in AsyncScanCommands().sscan_iter("")]
+        mock_execute_command.assert_called_with('SSCAN', '', '0', _iter_req_id="uuid")
+    with mock.patch.object(
+        AsyncScanCommands,
+        "execute_command", 
+        AsyncMock(return_value=(0, {}))
+    ) as mock_execute_command, mock.patch.object(uuid, "uuid4", return_value="uuid"):
+        [a async for a in AsyncScanCommands().hscan_iter("")]
+        mock_execute_command.assert_called_with('HSCAN', '', '0', no_values=None, _iter_req_id="uuid")
+        [a async for a in AsyncScanCommands().zscan_iter("")]
+        mock_execute_command.assert_called_with('ZSCAN', '', '0', score_cast_func=ANY, _iter_req_id="uuid")

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -48,7 +48,7 @@ class SentinelManagedConnectionMock(SentinelManagedConnection):
         """
         This simulates the behavior of _connect_to_sentinel when
         :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`.
-        In master mode, it'll connect to the master. 
+        In master mode, it'll connect to the master.
         In non-master mode, it'll call rotate_slaves and connect to the next replica.
         """
         if self.connection_pool.is_master:

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -82,7 +82,7 @@ class SentinelManagedConnectionMockForMasterMode(SentinelManagedConnectionMock):
 async def connection_pool_replica_mock() -> SentinelConnectionPool:
     sentinel_manager = Sentinel([["master", 400]])
     # Give a random slave
-    sentinel_manager.discover_slaves = AsyncMock(return_value=["replica", 5000])  # type: ignore[method-assign]
+    sentinel_manager.discover_slaves = AsyncMock(return_value=["replica", 5000])
     # Create connection pool with our mock connection object
     connection_pool = SentinelConnectionPool(
         "usasm",
@@ -97,7 +97,7 @@ async def connection_pool_replica_mock() -> SentinelConnectionPool:
 async def connection_pool_master_mock() -> SentinelConnectionPool:
     sentinel_manager = Sentinel([["master", 400]])
     # Give a random slave
-    sentinel_manager.discover_master = AsyncMock(return_value=["replica", 5000])  # type: ignore[method-assign]
+    sentinel_manager.discover_master = AsyncMock(return_value=["replica", 5000])
     # Create connection pool with our mock connection object
     connection_pool = SentinelConnectionPool(
         "usasm",

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -47,9 +47,9 @@ class SentinelManagedConnectionMock(SentinelManagedConnection):
     async def _connect_to_sentinel(self) -> None:
         """
         This simulates the behavior of _connect_to_sentinel when
-        :py:class:`~redis.SentinelConnectionPool`
-        is in replica mode.
-        It'll call rotate_slaves and connect to the next replica.
+        :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`.
+        In master mode, it'll connect to the master. 
+        In non-master mode, it'll call rotate_slaves and connect to the next replica.
         """
         if self.connection_pool.is_master:
             self.host, self.port = ("master", 1)
@@ -62,7 +62,8 @@ class SentinelManagedConnectionMock(SentinelManagedConnection):
 
     async def connect_to(self, address: Tuple[str, int]) -> None:
         """
-        Do nothing, just mock.
+        Do nothing, just mock so it won't try to make a connection to the
+        dummy address.
         """
 
 

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -1,14 +1,15 @@
 import socket
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
 from redis.asyncio.retry import Retry
-from redis.asyncio.sentinel import SentinelManagedConnection, SentinelConnectionPool, Sentinel
+from redis.asyncio.sentinel import (
+    Sentinel,
+    SentinelConnectionPool,
+    SentinelManagedConnection,
+)
 from redis.backoff import NoBackoff
-from unittest.mock import AsyncMock
-from typing import AsyncIterator
-
-import pytest
 
 from .compat import mock
 
@@ -41,6 +42,7 @@ async def test_connect_retry_on_timeout_error(connect_args):
     assert conn._connect.call_count == 3
     await conn.disconnect()
 
+
 class SentinelManagedConnectionMock(SentinelManagedConnection):
     async def connect_to_address(self, host: str, port: int) -> None:
         self.host = host
@@ -56,9 +58,10 @@ class SentinelManagedConnectionMock(SentinelManagedConnection):
 class SentinelManagedConnectionMockForReplicaMode(SentinelManagedConnectionMock):
     async def connect(self) -> None:
         """
-        This simulates the behavior of connect when the ``redis.asyncio.sentinel.SentinelConnectionPool``
+        This simulates the behavior of connect when
+        :py:class:`~redis.SentinelConnectionPool`
         is in replica mode.
-        It'll call rotate_slaves and connect to the next replica
+        It'll call rotate_slaves and connect to the next replica.
         """
         import random
         import time
@@ -70,10 +73,11 @@ class SentinelManagedConnectionMockForReplicaMode(SentinelManagedConnectionMock)
 class SentinelManagedConnectionMockForMasterMode(SentinelManagedConnectionMock):
     async def connect_to(self, address: tuple[str, int]) -> None:
         """
-        This simulates the behavior of connect_to when the ``redis.asyncio.sentinel.SentinelConnectionPool``
+        This simulates the behavior of connect_to when
+        :py:class:`~redis.SentinelConnectionPool`
         is in master mode.
-        It'll try to connect to master but we should not create any connection in test,
-        so just set the host and port without actually connecting.
+        It'll try to connect to master. In this mock class,
+        it'll just set the host and port without actually connecting.
         """
         self.host, self.port = address
 
@@ -113,27 +117,41 @@ def same_address(
     connection_2: SentinelManagedConnection,
 ) -> bool:
     return bool(
-        connection_1.host == connection_2.host and connection_1.port == connection_2.port
+        connection_1.host == connection_2.host
+        and connection_1.port == connection_2.port
     )
 
-async def test_connection_pool_connects_to_same_address_if_same_iter_req_id_in_replica_mode(
+
+async def test_connects_to_same_address_if_same_id_replica(
     connection_pool_replica_mock: SentinelConnectionPool,
 ) -> None:
-    # Assert that the connection address is the same if the _iter_req_id is the same
-    connection_for_req_1 = await connection_pool_replica_mock.get_connection("ANY", _iter_req_id=1)
+    """
+    Assert that the connection address is the same if the ``_iter_req_id`` is the same
+    when we are in replica mode using a
+    :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`
+    """
+    connection_for_req_1 = await connection_pool_replica_mock.get_connection(
+        "ANY", _iter_req_id=1
+    )
     assert same_address(
-        await connection_pool_replica_mock.get_connection(
-            "ANY", _iter_req_id=1
-        ),
+        await connection_pool_replica_mock.get_connection("ANY", _iter_req_id=1),
         connection_for_req_1,
     )
 
 
-async def test_connection_pool_returns_same_conn_object_if_same_iter_req_id_and_released_in_replica_mode(
+async def test_connects_to_same_conn_object_if_same_id_and_conn_released_replica(
     connection_pool_replica_mock: SentinelConnectionPool,
 ) -> None:
-    # Assert that the connection object is the same if the _iter_req_id is the same
-    connection_for_req_1 = await connection_pool_replica_mock.get_connection("ANY", _iter_req_id=1)
+    """
+    Assert that the connection object is the same if the ``_iter_req_id`` is the same
+    when we are in replica mode using a
+    :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`
+    and if we release the connection back to the connection pool before
+    trying to connect again
+    """
+    connection_for_req_1 = await connection_pool_replica_mock.get_connection(
+        "ANY", _iter_req_id=1
+    )
     await connection_pool_replica_mock.release(connection_for_req_1)
     assert (
         await connection_pool_replica_mock.get_connection("ANY", _iter_req_id=1)
@@ -141,60 +159,84 @@ async def test_connection_pool_returns_same_conn_object_if_same_iter_req_id_and_
     )
 
 
-async def test_connection_pool_connects_to_diff_address_if_no_iter_req_id_in_replica_mode(
+async def test_connects_to_diff_address_if_no_iter_req_id_replica(
     connection_pool_replica_mock: SentinelConnectionPool,
 ) -> None:
-    # Assert that the connection object is different if no _iter_req_id is supplied
-    # In reality, they can be the same, but in this case, we're not releasing the connection
-    # to the pool so they should always be different.
-    connection_for_req_1 = await connection_pool_replica_mock.get_connection("ANY", _iter_req_id=1)
-    connection_for_random_req = await connection_pool_replica_mock.get_connection("ANYY")
+    """
+    Assert that the connection object is different if no _iter_req_id is supplied
+    In reality, they can be the same, but in this case, we're not
+    releasing the connection to the pool so they should always be different.
+    """
+    connection_for_req_1 = await connection_pool_replica_mock.get_connection(
+        "ANY", _iter_req_id=1
+    )
+    connection_for_random_req = await connection_pool_replica_mock.get_connection(
+        "ANYY"
+    )
     assert not same_address(connection_for_random_req, connection_for_req_1)
     assert not same_address(
         await connection_pool_replica_mock.get_connection("ANY_COMMAND"),
         connection_for_random_req,
     )
     assert not same_address(
-        await connection_pool_replica_mock.get_connection(
-            "ANY_COMMAND"
-        ),
+        await connection_pool_replica_mock.get_connection("ANY_COMMAND"),
         connection_for_req_1,
     )
 
 
-async def test_connection_pool_connects_to_same_address_if_same_iter_req_id_in_master_mode(
+async def test_connects_to_same_address_if_same_iter_req_id_master(
     connection_pool_master_mock: SentinelConnectionPool,
 ) -> None:
-    # Assert that the connection address is the same if the _iter_req_id is the same
-    connection_for_req_1 = await connection_pool_master_mock.get_connection("ANY", _iter_req_id=1)
-    assert same_address(
-        await connection_pool_master_mock.get_connection(
-            "ANY", _iter_req_id=1
-        ),
-        connection_for_req_1,
+    """
+    Assert that the connection address is the same if the ``_iter_req_id`` is the same
+    when we are in master mode using a
+    :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`
+    """
+    connection_for_req_1 = await connection_pool_master_mock.get_connection(
+        "ANY", _iter_req_id=1
     )
-
-
-async def test_connection_pool_returns_same_conn_object_if_same_iter_req_id_and_released_in_master_mode(
-    connection_pool_master_mock: SentinelConnectionPool,
-) -> None:
-    # Assert that the connection address is the same if the _iter_req_id is the same
-    connection_for_req_1 = await connection_pool_master_mock.get_connection("ANY", _iter_req_id=1)
     assert same_address(
         await connection_pool_master_mock.get_connection("ANY", _iter_req_id=1),
         connection_for_req_1,
     )
 
-async def test_connection_pool_connects_to_same_address_if_no_iter_req_id_in_master_mode(
+
+async def test_connects_to_same_conn_object_if_same_iter_req_id_and_released_master(
     connection_pool_master_mock: SentinelConnectionPool,
 ) -> None:
-    # Assert that connection address is always the same regardless if it's an iter command or not
-    connection_for_req_1 = await connection_pool_master_mock.get_connection("ANY", _iter_req_id=1)
+    """
+    Assert that the connection address is the same if the ``_iter_req_id`` is the same
+    when we are in master mode using a
+    :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`
+    and if we release the connection back to the connection pool before
+    trying to connect again
+    """
+    connection_for_req_1 = await connection_pool_master_mock.get_connection(
+        "ANY", _iter_req_id=1
+    )
+    assert same_address(
+        await connection_pool_master_mock.get_connection("ANY", _iter_req_id=1),
+        connection_for_req_1,
+    )
+
+
+async def test_connects_to_same_address_if_no_iter_req_id_in_master(
+    connection_pool_master_mock: SentinelConnectionPool,
+) -> None:
+    """
+    Assert that connection address is always the same regardless if
+    there's an ``iter_req_id`` or not
+    when we are in master mode using a
+    :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`
+    """
+    connection_for_req_1 = await connection_pool_master_mock.get_connection(
+        "ANY", _iter_req_id=1
+    )
     connection_for_random_req = await connection_pool_master_mock.get_connection("ANYY")
     assert same_address(connection_for_random_req, connection_for_req_1)
     assert same_address(
         await connection_pool_master_mock.get_connection("ANY_COMMAND"),
-        connection_for_random_req
+        connection_for_random_req,
     )
 
     assert same_address(

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -43,9 +43,8 @@ async def test_connect_retry_on_timeout_error(connect_args):
 
 
 class SentinelManagedConnectionMock(SentinelManagedConnection):
-    async def connect_to_address(self, host: str, port: int) -> None:
-        self.host = host
-        self.port = port
+    async def connect_to_same_address(self) -> None:
+        pass
 
     async def can_read_destructive(self) -> bool:
         # Mock this function to always return False.

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -1,18 +1,18 @@
 import socket
+import uuid
 from typing import Tuple
-from unittest.mock import AsyncMock, ANY
+from unittest.mock import ANY, AsyncMock
 
 import pytest
 import pytest_asyncio
-import uuid
 from redis.asyncio.retry import Retry
-from redis.commands.core import AsyncScanCommands
 from redis.asyncio.sentinel import (
     Sentinel,
     SentinelConnectionPool,
     SentinelManagedConnection,
 )
 from redis.backoff import NoBackoff
+from redis.commands.core import AsyncScanCommands
 
 from .compat import mock
 
@@ -251,20 +251,20 @@ async def test_connects_to_same_address_if_no_iter_req_id_master(
 async def test_scan_iter_family_executes_commands_with_same_iter_req_id():
     """Assert that all calls to execute_command receives the _iter_req_id kwarg"""
     with mock.patch.object(
-        AsyncScanCommands,
-        "execute_command", 
-        AsyncMock(return_value=(0, []))
+        AsyncScanCommands, "execute_command", AsyncMock(return_value=(0, []))
     ) as mock_execute_command, mock.patch.object(uuid, "uuid4", return_value="uuid"):
         [a async for a in AsyncScanCommands().scan_iter()]
-        mock_execute_command.assert_called_with('SCAN', '0', _iter_req_id="uuid")
+        mock_execute_command.assert_called_with("SCAN", "0", _iter_req_id="uuid")
         [a async for a in AsyncScanCommands().sscan_iter("")]
-        mock_execute_command.assert_called_with('SSCAN', '', '0', _iter_req_id="uuid")
+        mock_execute_command.assert_called_with("SSCAN", "", "0", _iter_req_id="uuid")
     with mock.patch.object(
-        AsyncScanCommands,
-        "execute_command", 
-        AsyncMock(return_value=(0, {}))
+        AsyncScanCommands, "execute_command", AsyncMock(return_value=(0, {}))
     ) as mock_execute_command, mock.patch.object(uuid, "uuid4", return_value="uuid"):
         [a async for a in AsyncScanCommands().hscan_iter("")]
-        mock_execute_command.assert_called_with('HSCAN', '', '0', no_values=None, _iter_req_id="uuid")
+        mock_execute_command.assert_called_with(
+            "HSCAN", "", "0", no_values=None, _iter_req_id="uuid"
+        )
         [a async for a in AsyncScanCommands().zscan_iter("")]
-        mock_execute_command.assert_called_with('ZSCAN', '', '0', score_cast_func=ANY, _iter_req_id="uuid")
+        mock_execute_command.assert_called_with(
+            "ZSCAN", "", "0", score_cast_func=ANY, _iter_req_id="uuid"
+        )

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -1,9 +1,14 @@
 import socket
 
 import pytest
+import pytest_asyncio
 from redis.asyncio.retry import Retry
-from redis.asyncio.sentinel import SentinelManagedConnection
+from redis.asyncio.sentinel import SentinelManagedConnection, SentinelConnectionPool, Sentinel
 from redis.backoff import NoBackoff
+from unittest.mock import AsyncMock
+from typing import AsyncIterator
+
+import pytest
 
 from .compat import mock
 
@@ -35,3 +40,165 @@ async def test_connect_retry_on_timeout_error(connect_args):
     await conn.connect()
     assert conn._connect.call_count == 3
     await conn.disconnect()
+
+
+def same_address(
+    connection_1: SentinelManagedConnection,
+    connection_2: SentinelManagedConnection,
+) -> bool:
+    return bool(
+        connection_1.host == connection_2.host and connection_1.port == connection_2.port
+    )
+
+class SentinelManagedConnectionMock(SentinelManagedConnection):
+    async def connect_to_address(self, host: str, port: int) -> None:
+        self.host = host
+        self.port = port
+
+    async def can_read_destructive(self) -> bool:
+        # Mock this function to always return False.
+        # Trrue means there's still data to be read and hence we can't reconnect
+        # to this connection yet
+        return False
+
+
+class SentinelManagedConnectionMockForReplicaMode(SentinelManagedConnectionMock):
+    async def connect(self) -> None:
+        """
+        This simulates the behavior of connect when the ``redis.asyncio.sentinel.SentinelConnectionPool``
+        is in replica mode.
+        It'll call rotate_slaves and connect to the next replica
+        """
+        import random
+        import time
+
+        self.host = f"host-{random.randint(0, 10)}"
+        self.port = time.time()
+
+
+class SentinelManagedConnectionMockForMasterMode(SentinelManagedConnectionMock):
+    async def connect_to(self, address: tuple[str, int]) -> None:
+        """
+        This simulates the behavior of connect_to when the ``redis.asyncio.sentinel.SentinelConnectionPool``
+        is in master mode.
+        It'll try to connect to master but we should not create any connection in test,
+        so just set the host and port without actually connecting.
+        """
+        self.host, self.port = address
+
+
+@pytest_asyncio.fixture()
+async def connection_pool_replica_mock() -> SentinelConnectionPool:
+    sentinel_manager = Sentinel([["master", 400]])
+    # Give a random slave
+    sentinel_manager.discover_slaves = AsyncMock(return_value=["replica", 5000])  # type: ignore[method-assign]
+    # Create connection pool with our mock connection object
+    connection_pool = SentinelConnectionPool(
+        "usasm",
+        sentinel_manager,
+        is_master=False,
+        connection_class=SentinelManagedConnectionMockForReplicaMode,
+    )
+    return connection_pool
+
+
+@pytest_asyncio.fixture()
+async def connection_pool_master_mock() -> SentinelConnectionPool:
+    sentinel_manager = Sentinel([["master", 400]]) 
+    # Give a random slave
+    sentinel_manager.discover_master = AsyncMock(return_value=["replica", 5000])  # type: ignore[method-assign]
+    # Create connection pool with our mock connection object
+    connection_pool = SentinelConnectionPool(
+        "usasm",
+        sentinel_manager,
+        is_master=True,
+        connection_class=SentinelManagedConnectionMockForMasterMode,
+    )
+    return connection_pool
+
+
+async def test_connection_pool_connects_to_same_address_if_same_iter_req_id_in_replica_mode(
+    connection_pool_replica_mock: SentinelConnectionPool,
+) -> None:
+    # Assert that the connection address is the same if the _iter_req_id is the same
+    connection_for_req_1 = await connection_pool_replica_mock.get_connection("ANY", _iter_req_id=1)
+    assert same_address(
+        await connection_pool_replica_mock.get_connection(
+            "ANY", _iter_req_id=1
+        ),
+        connection_for_req_1,
+    )
+
+
+async def test_connection_pool_returns_same_conn_object_if_same_iter_req_id_and_released_in_replica_mode(
+    connection_pool_replica_mock: SentinelConnectionPool,
+) -> None:
+    # Assert that the connection object is the same if the _iter_req_id is the same
+    connection_for_req_1 = await connection_pool_replica_mock.get_connection("ANY", _iter_req_id=1)
+    await connection_pool_replica_mock.release(connection_for_req_1)
+    assert (
+        await connection_pool_replica_mock.get_connection("ANY", _iter_req_id=1)
+        == connection_for_req_1
+    )
+
+
+async def test_connection_pool_connects_to_diff_address_if_no_iter_req_id_in_replica_mode(
+    connection_pool_replica_mock: SentinelConnectionPool,
+) -> None:
+    # Assert that the connection object is different if no _iter_req_id is supplied
+    # In reality, they can be the same, but in this case, we're not releasing the connection
+    # to the pool so they should always be different.
+    connection_for_req_1 = await connection_pool_replica_mock.get_connection("ANY", _iter_req_id=1)
+    connection_for_random_req = await connection_pool_replica_mock.get_connection("ANYY")
+    assert not same_address(connection_for_random_req, connection_for_req_1)
+    assert not same_address(
+        await connection_pool_replica_mock.get_connection("ANY_COMMAND"),
+        connection_for_random_req,
+    )
+    assert not same_address(
+        await connection_pool_replica_mock.get_connection(
+            "ANY_COMMAND"
+        ),
+        connection_for_req_1,
+    )
+
+
+async def test_connection_pool_connects_to_same_address_if_same_iter_req_id_in_master_mode(
+    connection_pool_master_mock: SentinelConnectionPool,
+) -> None:
+    # Assert that the connection address is the same if the _iter_req_id is the same
+    connection_for_req_1 = await connection_pool_master_mock.get_connection("ANY", _iter_req_id=1)
+    assert same_address(
+        await connection_pool_master_mock.get_connection(
+            "ANY", _iter_req_id=1
+        ),
+        connection_for_req_1,
+    )
+
+
+async def test_connection_pool_returns_same_conn_object_if_same_iter_req_id_and_released_in_master_mode(
+    connection_pool_master_mock: SentinelConnectionPool,
+) -> None:
+    # Assert that the connection address is the same if the _iter_req_id is the same
+    connection_for_req_1 = await connection_pool_master_mock.get_connection("ANY", _iter_req_id=1)
+    assert same_address(
+        await connection_pool_master_mock.get_connection("ANY", _iter_req_id=1),
+        connection_for_req_1,
+    )
+
+async def test_connection_pool_connects_to_same_address_if_no_iter_req_id_in_master_mode(
+    connection_pool_master_mock: SentinelConnectionPool,
+) -> None:
+    # Assert that connection address is always the same regardless if it's an iter command or not
+    connection_for_req_1 = await connection_pool_master_mock.get_connection("ANY", _iter_req_id=1)
+    connection_for_random_req = await connection_pool_master_mock.get_connection("ANYY")
+    assert same_address(connection_for_random_req, connection_for_req_1)
+    assert same_address(
+        await connection_pool_master_mock.get_connection("ANY_COMMAND"),
+        connection_for_random_req
+    )
+    
+    assert same_address(
+        await connection_pool_master_mock.get_connection("ANY_COMMAND"),
+        connection_for_req_1,
+    )

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -129,7 +129,7 @@ async def test_connects_to_same_address_if_same_id_replica(
     """
     Assert that the connection address is the same if the ``_iter_req_id`` is the same
     when we are in replica mode using a
-    :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`
+    :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`.
     """
     connection_for_req_1 = await connection_pool_replica_mock.get_connection(
         "ANY", _iter_req_id=1
@@ -148,7 +148,7 @@ async def test_connects_to_same_conn_object_if_same_id_and_conn_released_replica
     when we are in replica mode using a
     :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`
     and if we release the connection back to the connection pool before
-    trying to connect again
+    trying to connect again.
     """
     connection_for_req_1 = await connection_pool_replica_mock.get_connection(
         "ANY", _iter_req_id=1
@@ -164,7 +164,7 @@ async def test_connects_to_diff_address_if_no_iter_req_id_replica(
     connection_pool_replica_mock: SentinelConnectionPool,
 ) -> None:
     """
-    Assert that the connection object is different if no _iter_req_id is supplied
+    Assert that the connection object is different if no _iter_req_id is supplied.
     In reality, they can be the same, but in this case, we're not
     releasing the connection to the pool so they should always be different.
     """
@@ -191,7 +191,7 @@ async def test_connects_to_same_address_if_same_iter_req_id_master(
     """
     Assert that the connection address is the same if the ``_iter_req_id`` is the same
     when we are in master mode using a
-    :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`
+    :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`.
     """
     connection_for_req_1 = await connection_pool_master_mock.get_connection(
         "ANY", _iter_req_id=1
@@ -210,7 +210,7 @@ async def test_connects_to_same_conn_object_if_same_iter_req_id_and_released_mas
     when we are in master mode using a
     :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`
     and if we release the connection back to the connection pool before
-    trying to connect again
+    trying to connect again.
     """
     connection_for_req_1 = await connection_pool_master_mock.get_connection(
         "ANY", _iter_req_id=1
@@ -221,14 +221,14 @@ async def test_connects_to_same_conn_object_if_same_iter_req_id_and_released_mas
     )
 
 
-async def test_connects_to_same_address_if_no_iter_req_id_in_master(
+async def test_connects_to_same_address_if_no_iter_req_id_master(
     connection_pool_master_mock: SentinelConnectionPool,
 ) -> None:
     """
     Assert that connection address is always the same regardless if
     there's an ``iter_req_id`` or not
     when we are in master mode using a
-    :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`
+    :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`.
     """
     connection_for_req_1 = await connection_pool_master_mock.get_connection(
         "ANY", _iter_req_id=1

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -124,15 +124,15 @@ async def test_connects_to_same_address_if_same_id_replica(
     connection_pool_replica_mock: SentinelConnectionPool,
 ) -> None:
     """
-    Assert that the connection address is the same if the ``_iter_req_id`` is the same
+    Assert that the connection address is the same if the ``iter_req_id`` is the same
     when we are in replica mode using a
     :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`.
     """
     connection_for_req_1 = await connection_pool_replica_mock.get_connection(
-        "ANY", _iter_req_id=1
+        "ANY", iter_req_id=1
     )
     assert same_address(
-        await connection_pool_replica_mock.get_connection("ANY", _iter_req_id=1),
+        await connection_pool_replica_mock.get_connection("ANY", iter_req_id=1),
         connection_for_req_1,
     )
 
@@ -141,32 +141,32 @@ async def test_connects_to_same_conn_object_if_same_id_and_conn_released_replica
     connection_pool_replica_mock: SentinelConnectionPool,
 ) -> None:
     """
-    Assert that the connection object is the same if the ``_iter_req_id`` is the same
+    Assert that the connection object is the same if the ``iter_req_id`` is the same
     when we are in replica mode using a
     :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`
     and if we release the connection back to the connection pool before
     trying to connect again.
     """
     connection_for_req_1 = await connection_pool_replica_mock.get_connection(
-        "ANY", _iter_req_id=1
+        "ANY", iter_req_id=1
     )
     await connection_pool_replica_mock.release(connection_for_req_1)
     assert (
-        await connection_pool_replica_mock.get_connection("ANY", _iter_req_id=1)
+        await connection_pool_replica_mock.get_connection("ANY", iter_req_id=1)
         == connection_for_req_1
     )
 
 
-async def test_connects_to_diff_address_if_no_iter_req_id_replica(
+async def test_connects_to_diff_address_if_noiter_req_id_replica(
     connection_pool_replica_mock: SentinelConnectionPool,
 ) -> None:
     """
-    Assert that the connection object is different if no _iter_req_id is supplied.
+    Assert that the connection object is different if no iter_req_id is supplied.
     In reality, they can be the same, but in this case, we're not
     releasing the connection to the pool so they should always be different.
     """
     connection_for_req_1 = await connection_pool_replica_mock.get_connection(
-        "ANY", _iter_req_id=1
+        "ANY", iter_req_id=1
     )
     connection_for_random_req = await connection_pool_replica_mock.get_connection(
         "ANYY"
@@ -182,43 +182,43 @@ async def test_connects_to_diff_address_if_no_iter_req_id_replica(
     )
 
 
-async def test_connects_to_same_address_if_same_iter_req_id_master(
+async def test_connects_to_same_address_if_sameiter_req_id_master(
     connection_pool_master_mock: SentinelConnectionPool,
 ) -> None:
     """
-    Assert that the connection address is the same if the ``_iter_req_id`` is the same
+    Assert that the connection address is the same if the ``iter_req_id`` is the same
     when we are in master mode using a
     :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`.
     """
     connection_for_req_1 = await connection_pool_master_mock.get_connection(
-        "ANY", _iter_req_id=1
+        "ANY", iter_req_id=1
     )
     assert same_address(
-        await connection_pool_master_mock.get_connection("ANY", _iter_req_id=1),
+        await connection_pool_master_mock.get_connection("ANY", iter_req_id=1),
         connection_for_req_1,
     )
 
 
-async def test_connects_to_same_conn_object_if_same_iter_req_id_and_released_master(
+async def test_connects_to_same_conn_object_if_sameiter_req_id_and_released_master(
     connection_pool_master_mock: SentinelConnectionPool,
 ) -> None:
     """
-    Assert that the connection address is the same if the ``_iter_req_id`` is the same
+    Assert that the connection address is the same if the ``iter_req_id`` is the same
     when we are in master mode using a
     :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`
     and if we release the connection back to the connection pool before
     trying to connect again.
     """
     connection_for_req_1 = await connection_pool_master_mock.get_connection(
-        "ANY", _iter_req_id=1
+        "ANY", iter_req_id=1
     )
     assert same_address(
-        await connection_pool_master_mock.get_connection("ANY", _iter_req_id=1),
+        await connection_pool_master_mock.get_connection("ANY", iter_req_id=1),
         connection_for_req_1,
     )
 
 
-async def test_connects_to_same_address_if_no_iter_req_id_master(
+async def test_connects_to_same_address_if_noiter_req_id_master(
     connection_pool_master_mock: SentinelConnectionPool,
 ) -> None:
     """
@@ -228,7 +228,7 @@ async def test_connects_to_same_address_if_no_iter_req_id_master(
     :py:class:`~redis.asyncio.sentinel.SentinelConnectionPool`.
     """
     connection_for_req_1 = await connection_pool_master_mock.get_connection(
-        "ANY", _iter_req_id=1
+        "ANY", iter_req_id=1
     )
     connection_for_random_req = await connection_pool_master_mock.get_connection("ANYY")
     assert same_address(connection_for_random_req, connection_for_req_1)
@@ -252,4 +252,4 @@ async def test_scan_iter_family_cleans_up(
     r = Redis(connection_pool=connection_pool_replica_mock)
 
     [k async for k in r.scan_iter("a")]
-    assert not connection_pool_replica_mock._iter_req_id_to_replica_address
+    assert not connection_pool_replica_mock.iter_req_id_to_replica_address

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -41,15 +41,6 @@ async def test_connect_retry_on_timeout_error(connect_args):
     assert conn._connect.call_count == 3
     await conn.disconnect()
 
-
-def same_address(
-    connection_1: SentinelManagedConnection,
-    connection_2: SentinelManagedConnection,
-) -> bool:
-    return bool(
-        connection_1.host == connection_2.host and connection_1.port == connection_2.port
-    )
-
 class SentinelManagedConnectionMock(SentinelManagedConnection):
     async def connect_to_address(self, host: str, port: int) -> None:
         self.host = host
@@ -104,7 +95,7 @@ async def connection_pool_replica_mock() -> SentinelConnectionPool:
 
 @pytest_asyncio.fixture()
 async def connection_pool_master_mock() -> SentinelConnectionPool:
-    sentinel_manager = Sentinel([["master", 400]]) 
+    sentinel_manager = Sentinel([["master", 400]])
     # Give a random slave
     sentinel_manager.discover_master = AsyncMock(return_value=["replica", 5000])  # type: ignore[method-assign]
     # Create connection pool with our mock connection object
@@ -116,6 +107,14 @@ async def connection_pool_master_mock() -> SentinelConnectionPool:
     )
     return connection_pool
 
+
+def same_address(
+    connection_1: SentinelManagedConnection,
+    connection_2: SentinelManagedConnection,
+) -> bool:
+    return bool(
+        connection_1.host == connection_2.host and connection_1.port == connection_2.port
+    )
 
 async def test_connection_pool_connects_to_same_address_if_same_iter_req_id_in_replica_mode(
     connection_pool_replica_mock: SentinelConnectionPool,
@@ -197,7 +196,7 @@ async def test_connection_pool_connects_to_same_address_if_no_iter_req_id_in_mas
         await connection_pool_master_mock.get_connection("ANY_COMMAND"),
         connection_for_random_req
     )
-    
+
     assert same_address(
         await connection_pool_master_mock.get_connection("ANY_COMMAND"),
         connection_for_req_1,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2235,8 +2235,8 @@ class TestRedisCommands:
         pairs = list(r.zscan_iter("a", match="a"))
         assert set(pairs) == {(b"a", 1)}
 
-    def test_scan_iter_family_executes_commands_with_same_iter_req_id(self):
-        """Assert that all calls to execute_command receives the _iter_req_id kwarg"""
+    def test_scan_iter_family_executes_commands_with_sameiter_req_id(self):
+        """Assert that all calls to execute_command receives the iter_req_id kwarg"""
         import uuid
 
         from redis.commands.core import ScanCommands
@@ -2247,10 +2247,10 @@ class TestRedisCommands:
             uuid, "uuid4", return_value="uuid"
         ):
             [a for a in ScanCommands().scan_iter()]
-            mock_execute_command.assert_called_with("SCAN", "0", _iter_req_id="uuid")
+            mock_execute_command.assert_called_with("SCAN", "0", iter_req_id="uuid")
             [a for a in ScanCommands().sscan_iter("")]
             mock_execute_command.assert_called_with(
-                "SSCAN", "", "0", _iter_req_id="uuid"
+                "SSCAN", "", "0", iter_req_id="uuid"
             )
         with mock.patch.object(
             ScanCommands, "execute_command", mock.Mock(return_value=(0, {}))
@@ -2259,11 +2259,11 @@ class TestRedisCommands:
         ):
             [a for a in ScanCommands().hscan_iter("")]
             mock_execute_command.assert_called_with(
-                "HSCAN", "", "0", no_values=None, _iter_req_id="uuid"
+                "HSCAN", "", "0", no_values=None, iter_req_id="uuid"
             )
             [a for a in ScanCommands().zscan_iter("")]
             mock_execute_command.assert_called_with(
-                "ZSCAN", "", "0", score_cast_func=mock.ANY, _iter_req_id="uuid"
+                "ZSCAN", "", "0", score_cast_func=mock.ANY, iter_req_id="uuid"
             )
 
     # SET COMMANDS

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2235,7 +2235,7 @@ class TestRedisCommands:
         pairs = list(r.zscan_iter("a", match="a"))
         assert set(pairs) == {(b"a", 1)}
 
-    def test_scan_iter_family_executes_commands_with_same_iter_req_id():
+    def test_scan_iter_family_executes_commands_with_same_iter_req_id(self):
         """Assert that all calls to execute_command receives the _iter_req_id kwarg"""
         import uuid
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2235,7 +2235,7 @@ class TestRedisCommands:
         pairs = list(r.zscan_iter("a", match="a"))
         assert set(pairs) == {(b"a", 1)}
 
-    def test_scan_iter_family_executes_commands_with_sameiter_req_id(self):
+    def test_scan_iter_family_executes_commands_with_same_iter_req_id(self):
         """Assert that all calls to execute_command receives the iter_req_id kwarg"""
         import uuid
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -10,7 +10,6 @@ from redis._parsers import _HiredisParser, _RESP2Parser, _RESP3Parser
 from redis.backoff import NoBackoff
 from redis.connection import (
     Connection,
-    ConnectionsIndexer,
     SSLConnection,
     UnixDomainSocketConnection,
     parse_url,
@@ -348,17 +347,3 @@ def test_unix_socket_connection_failure():
         == "Error 2 connecting to unix:///tmp/a.sock. No such file or directory."
     )
 
-
-def test_connections_indexer_operations():
-    ci = ConnectionsIndexer()
-    c1 = Connection(host="1", port=2)
-    ci.append(c1)
-    assert list(ci) == [c1]
-    assert ci.pop() == c1
-
-    c2 = Connection(host="3", port=4)
-    ci.append(c1)
-    ci.append(c2)
-    assert ci.get_connection("3", 4) == c2
-    assert not ci.get_connection("5", 6)
-    assert list(ci) == [c1]

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -10,6 +10,7 @@ from redis._parsers import _HiredisParser, _RESP2Parser, _RESP3Parser
 from redis.backoff import NoBackoff
 from redis.connection import (
     Connection,
+    ConnectionsIndexer,
     SSLConnection,
     UnixDomainSocketConnection,
     parse_url,
@@ -297,7 +298,6 @@ def test_redis_from_pool(request, from_url):
     assert called == 1
     pool.disconnect()
 
-
 @pytest.mark.parametrize(
     "conn, error, expected_message",
     [
@@ -346,3 +346,17 @@ def test_unix_socket_connection_failure():
         str(e.value)
         == "Error 2 connecting to unix:///tmp/a.sock. No such file or directory."
     )
+
+def test_connections_indexer_operations():
+    ci = ConnectionsIndexer()
+    c1 = Connection(host="1", port=2)
+    ci.append(c1)
+    assert list(ci) == [c1]
+    assert ci.pop() == c1
+
+    c2 = Connection(host="3", port=4)
+    ci.append(c1)
+    ci.append(c2)
+    assert ci.get_connection("3", 4) == c2
+    assert not ci.get_connection("5", 6)
+    assert list(ci) == [c1]

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -298,6 +298,7 @@ def test_redis_from_pool(request, from_url):
     assert called == 1
     pool.disconnect()
 
+
 @pytest.mark.parametrize(
     "conn, error, expected_message",
     [
@@ -346,6 +347,7 @@ def test_unix_socket_connection_failure():
         str(e.value)
         == "Error 2 connecting to unix:///tmp/a.sock. No such file or directory."
     )
+
 
 def test_connections_indexer_operations():
     ci = ConnectionsIndexer()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -346,4 +346,3 @@ def test_unix_socket_connection_failure():
         str(e.value)
         == "Error 2 connecting to unix:///tmp/a.sock. No such file or directory."
     )
-

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -530,7 +530,7 @@ class TestConnection:
         pool = r.connection_pool
         assert not pipe.connection
         assert len(pool._available_connections) == 1
-        assert not pool.list(available_connections)[0]._sock
+        assert not list(pool._available_connections)[0]._sock
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("2.8.8")
@@ -547,7 +547,7 @@ class TestConnection:
         pool = r.connection_pool
         assert not pipe.connection
         assert len(pool._available_connections) == 1
-        assert not pool.list(available_connections)[0]._sock
+        assert not list(pool._available_connections)[0]._sock
 
     @skip_if_server_version_lt("2.8.8")
     @skip_if_redis_enterprise()

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -530,7 +530,7 @@ class TestConnection:
         pool = r.connection_pool
         assert not pipe.connection
         assert len(pool._available_connections) == 1
-        assert not pool._list(available_connections)[0]._sock
+        assert not pool.list(available_connections)[0]._sock
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("2.8.8")
@@ -547,7 +547,7 @@ class TestConnection:
         pool = r.connection_pool
         assert not pipe.connection
         assert len(pool._available_connections) == 1
-        assert not pool._list(available_connections)[0]._sock
+        assert not pool.list(available_connections)[0]._sock
 
     @skip_if_server_version_lt("2.8.8")
     @skip_if_redis_enterprise()

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -530,7 +530,7 @@ class TestConnection:
         pool = r.connection_pool
         assert not pipe.connection
         assert len(pool._available_connections) == 1
-        assert not pool._available_connections[0]._sock
+        assert not pool._list(available_connections)[0]._sock
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("2.8.8")
@@ -547,7 +547,7 @@ class TestConnection:
         pool = r.connection_pool
         assert not pipe.connection
         assert len(pool._available_connections) == 1
-        assert not pool._available_connections[0]._sock
+        assert not pool._list(available_connections)[0]._sock
 
     @skip_if_server_version_lt("2.8.8")
     @skip_if_redis_enterprise()

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -502,7 +502,7 @@ class TestConnection:
             bad_connection.info()
         pool = bad_connection.connection_pool
         assert len(pool._available_connections) == 1
-        assert not pool._available_connections[0]._sock
+        assert not list(pool._available_connections)[0]._sock
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("2.8.8")

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -20,6 +20,8 @@ class DummyConnection:
     def __init__(self, **kwargs):
         self.kwargs = kwargs
         self.pid = os.getpid()
+        self.host = kwargs.get("host", None)
+        self.port = kwargs.get("port", None)
 
     def connect(self):
         pass

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -41,6 +41,15 @@ def test_bulk(client):
 
 
 @pytest.mark.redismod
+def test_graph_creation_throws_deprecation_warning(client):
+    """Verify that a DeprecationWarning is raised when creating a Graph instance."""
+
+    match = "RedisGraph support is deprecated as of Redis Stack 7.2"
+    with pytest.warns(DeprecationWarning, match=match):
+        client.graph()
+
+
+@pytest.mark.redismod
 @skip_if_resp_version(3)
 def test_graph_creation(client):
     graph = client.graph()

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -446,7 +446,6 @@ def test_json_forget_with_dollar(client):
     client.json().forget("not_a_document", "..a")
 
 
-@pytest.mark.onlynoncluster
 @pytest.mark.redismod
 def test_json_mget_dollar(client):
     # Test mget with multi paths

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -257,4 +257,4 @@ class TestLockClassSelection:
                 pass
 
         lock = r.lock("foo", lock_class=MyLock)
-        assert type(lock) == MyLock
+        assert isinstance(lock, MyLock)

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -5,6 +5,7 @@ import pytest
 import redis.sentinel
 from redis import exceptions
 from redis.sentinel import (
+    ConnectionsIndexer,
     MasterNotFoundError,
     Sentinel,
     SentinelConnectionPool,
@@ -266,3 +267,18 @@ def test_auto_close_pool(cluster, sentinel, method_name):
 
     assert calls == 1
     pool.disconnect()
+
+
+def test_connections_indexer_operations():
+    ci = ConnectionsIndexer()
+    c1 = Connection(host="1", port=2)
+    ci.append(c1)
+    assert list(ci) == [c1]
+    assert ci.pop() == c1
+
+    c2 = Connection(host="3", port=4)
+    ci.append(c1)
+    ci.append(c2)
+    assert ci.get_connection("3", 4) == c2
+    assert not ci.get_connection("5", 6)
+    assert list(ci) == [c1]

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 import redis.sentinel
 from redis import exceptions
+from redis.connection import Connection
 from redis.sentinel import (
     ConnectionsIndexer,
     MasterNotFoundError,

--- a/tests/test_sentinel_managed_connection.py
+++ b/tests/test_sentinel_managed_connection.py
@@ -42,9 +42,8 @@ def test_connect_retry_on_timeout_error(connect_args):
 
 
 class SentinelManagedConnectionMock(SentinelManagedConnection):
-    def connect_to_address(self, host: str, port: int) -> None:
-        self.host = host
-        self.port = port
+    def connect_to_same_address(self) -> None:
+        pass
 
     def can_read_destructive(self) -> bool:
         # Mock this function to always return False.

--- a/tests/test_sentinel_managed_connection.py
+++ b/tests/test_sentinel_managed_connection.py
@@ -2,11 +2,9 @@ from typing import Tuple
 from unittest import mock
 
 import pytest
-from redis.sentinel import (
-    Sentinel,
-    SentinelConnectionPool,
-    SentinelManagedConnection,
-)
+from redis import Redis
+from redis.sentinel import Sentinel, SentinelConnectionPool, SentinelManagedConnection
+
 
 class SentinelManagedConnectionMock(SentinelManagedConnection):
     def connect_to_same_address(self) -> None:
@@ -211,8 +209,6 @@ def test_scan_iter_in_redis_cleans_up(
     connection_pool_replica_mock: SentinelConnectionPool,
 ):
     """Test that connection pool is correctly cleaned up"""
-    from redis import Redis
-
     r = Redis(connection_pool=connection_pool_replica_mock)
     # Patch the actual sending and parsing response from the Connection object
     # but still let the connection pool does all the necessary work
@@ -221,4 +217,3 @@ def test_scan_iter_in_redis_cleans_up(
     # Test that the iter_req_id for the scan command is cleared at the
     # end of the SCAN ITER command
     assert not connection_pool_replica_mock._iter_req_id_to_replica_address
-

--- a/tests/test_sentinel_managed_connection.py
+++ b/tests/test_sentinel_managed_connection.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 from redis import Redis
 from redis.sentinel import Sentinel, SentinelConnectionPool, SentinelManagedConnection
+from redis.utils import HIREDIS_AVAILABLE
 
 pytestmark = pytest.mark.skipif(HIREDIS_AVAILABLE, reason="PythonParser only")
 

--- a/tests/test_sentinel_managed_connection.py
+++ b/tests/test_sentinel_managed_connection.py
@@ -88,15 +88,15 @@ def test_connects_to_same_address_if_same_id_replica(
     connection_pool_replica_mock: SentinelConnectionPool,
 ) -> None:
     """
-    Assert that the connection address is the same if the ``_iter_req_id`` is the same
+    Assert that the connection address is the same if the ``iter_req_id`` is the same
     when we are in replica mode using a
     :py:class:`~redis.sentinel.SentinelConnectionPool`.
     """
     connection_for_req_1 = connection_pool_replica_mock.get_connection(
-        "ANY", _iter_req_id=1
+        "ANY", iter_req_id=1
     )
     assert same_address(
-        connection_pool_replica_mock.get_connection("ANY", _iter_req_id=1),
+        connection_pool_replica_mock.get_connection("ANY", iter_req_id=1),
         connection_for_req_1,
     )
 
@@ -105,18 +105,18 @@ def test_connects_to_same_conn_object_if_same_id_and_conn_released_replica(
     connection_pool_replica_mock: SentinelConnectionPool,
 ) -> None:
     """
-    Assert that the connection object is the same if the ``_iter_req_id`` is the same
+    Assert that the connection object is the same if the ``iter_req_id`` is the same
     when we are in replica mode using a
     :py:class:`~redis.sentinel.SentinelConnectionPool`
     and if we release the connection back to the connection pool before
     trying to connect again.
     """
     connection_for_req_1 = connection_pool_replica_mock.get_connection(
-        "ANY", _iter_req_id=1
+        "ANY", iter_req_id=1
     )
     connection_pool_replica_mock.release(connection_for_req_1)
     assert (
-        connection_pool_replica_mock.get_connection("ANY", _iter_req_id=1)
+        connection_pool_replica_mock.get_connection("ANY", iter_req_id=1)
         == connection_for_req_1
     )
 
@@ -125,12 +125,12 @@ def test_connects_to_diff_address_if_no_iter_req_id_replica(
     connection_pool_replica_mock: SentinelConnectionPool,
 ) -> None:
     """
-    Assert that the connection object is different if no _iter_req_id is supplied.
+    Assert that the connection object is different if no iter_req_id is supplied.
     In reality, they can be the same, but in this case, we're not
     releasing the connection to the pool so they should always be different.
     """
     connection_for_req_1 = connection_pool_replica_mock.get_connection(
-        "ANY", _iter_req_id=1
+        "ANY", iter_req_id=1
     )
     connection_for_random_req = connection_pool_replica_mock.get_connection("ANYY")
     assert not same_address(connection_for_random_req, connection_for_req_1)
@@ -156,7 +156,7 @@ def test_connects_to_same_address_if_same_iter_req_id_master(
         "ANY", _iter_req_id=1
     )
     assert same_address(
-        connection_pool_master_mock.get_connection("ANY", _iter_req_id=1),
+        connection_pool_master_mock.get_connection("ANY", iter_req_id=1),
         connection_for_req_1,
     )
 
@@ -172,10 +172,10 @@ def test_connects_to_same_conn_object_if_same_iter_req_id_and_released_master(
     trying to connect again.
     """
     connection_for_req_1 = connection_pool_master_mock.get_connection(
-        "ANY", _iter_req_id=1
+        "ANY", iter_req_id=1
     )
     assert same_address(
-        connection_pool_master_mock.get_connection("ANY", _iter_req_id=1),
+        connection_pool_master_mock.get_connection("ANY", iter_req_id=1),
         connection_for_req_1,
     )
 
@@ -190,7 +190,7 @@ def test_connects_to_same_address_if_no_iter_req_id_master(
     :py:class:`~redis.sentinel.SentinelConnectionPool`.
     """
     connection_for_req_1 = connection_pool_master_mock.get_connection(
-        "ANY", _iter_req_id=1
+        "ANY", iter_req_id=1
     )
     connection_for_random_req = connection_pool_master_mock.get_connection("ANYY")
     assert same_address(connection_for_random_req, connection_for_req_1)

--- a/tests/test_sentinel_managed_connection.py
+++ b/tests/test_sentinel_managed_connection.py
@@ -5,6 +5,8 @@ import pytest
 from redis import Redis
 from redis.sentinel import Sentinel, SentinelConnectionPool, SentinelManagedConnection
 
+pytestmark = pytest.mark.skipif(HIREDIS_AVAILABLE, reason="PythonParser only")
+
 
 class SentinelManagedConnectionMock(SentinelManagedConnection):
     def _connect_to_sentinel(self) -> None:

--- a/tests/test_sentinel_managed_connection.py
+++ b/tests/test_sentinel_managed_connection.py
@@ -213,7 +213,10 @@ def test_scan_iter_family_cleans_up(
     """Test that connection pool is correctly cleaned up"""
     from redis import Redis
 
-    r = Redis(connection_pool=connection_pool_replica_mock)
+    from redis.commands.core import ScanCommands
 
-    [k for k in r.scan_iter("a")]
+    r = Redis(connection_pool=connection_pool_replica_mock)
+    with mock.patch.object(r, "_send_command_parse_response", return_value=(0, [])):
+        [k for k in r.scan_iter("a")]
     assert not connection_pool_replica_mock._iter_req_id_to_replica_address
+

--- a/tests/test_sentinel_managed_connection.py
+++ b/tests/test_sentinel_managed_connection.py
@@ -14,7 +14,7 @@ class SentinelManagedConnectionMock(SentinelManagedConnection):
         """
         This simulates the behavior of _connect_to_sentinel when
         :py:class:`~redis.SentinelConnectionPool`.
-        In master mode, it'll connect to the master. 
+        In master mode, it'll connect to the master.
         In non-master mode, it'll call rotate_slaves and connect to the next replica.
         """
         if self.connection_pool.is_master:

--- a/tests/test_sentinel_managed_connection.py
+++ b/tests/test_sentinel_managed_connection.py
@@ -23,16 +23,11 @@ class SentinelManagedConnectionMock(SentinelManagedConnection):
             self.host = f"host-{random.randint(0, 10)}"
             self.port = time.time()
 
-
-class SentinelManagedConnectionMock(SentinelManagedConnectionMock):
     def connect_to(self, address: Tuple[str, int]) -> None:
         """
-        This simulates the behavior of connect_to when
-        :py:class:`~redis.SentinelConnectionPool`
-        is in master mode.
-        It'll try to connect to master. In this mock class,
-        it'll just set the host and port without actually connecting.
+        Do nothing, this is just to mock.
         """
+        pass
 
 
 @pytest.fixture()

--- a/tests/test_sentinel_managed_connection.py
+++ b/tests/test_sentinel_managed_connection.py
@@ -222,23 +222,3 @@ def test_scan_iter_in_redis_cleans_up(
     # end of the SCAN ITER command
     assert not connection_pool_replica_mock._iter_req_id_to_replica_address
 
-def test_scan_iter_in_pipeline_cleans_up(
-    connection_pool_replica_mock: SentinelConnectionPool,
-):
-    """Test that connection pool is correctly cleaned up"""
-    from redis import Redis
-
-    from redis.commands.core import ScanCommands
-
-    r = Redis(connection_pool=connection_pool_replica_mock)
-    r.pipeline()
-    r.scan_iter("a")
-    # Patch the actual sending and parsing response from the Connection object
-    # but still let the connection pool does all the necessary work
-    with mock.patch.object(r, "_send_command_parse_response", return_value=(0, [])):
-        r.execute()
-        [k for k in r.scan_iter("a")]
-    # Test that the iter_req_id for the scan command is cleared at the
-    # end of the SCAN ITER command
-    assert not connection_pool_replica_mock._iter_req_id_to_replica_address
-

--- a/tests/test_sentinel_managed_connection.py
+++ b/tests/test_sentinel_managed_connection.py
@@ -13,9 +13,9 @@ class SentinelManagedConnectionMock(SentinelManagedConnection):
     def _connect_to_sentinel(self) -> None:
         """
         This simulates the behavior of _connect_to_sentinel when
-        :py:class:`~redis.SentinelConnectionPool`
-        is in replica mode.
-        It'll call rotate_slaves and connect to the next replica.
+        :py:class:`~redis.SentinelConnectionPool`.
+        In master mode, it'll connect to the master. 
+        In non-master mode, it'll call rotate_slaves and connect to the next replica.
         """
         if self.connection_pool.is_master:
             self.host, self.port = ("master", 1)
@@ -28,7 +28,8 @@ class SentinelManagedConnectionMock(SentinelManagedConnection):
 
     def connect_to(self, address: Tuple[str, int]) -> None:
         """
-        Do nothing, this is just to mock.
+        Do nothing, just mock so it won't try to make a connection to the
+        dummy address.
         """
         pass
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Do tests and lints pass with this change?
   - [x] lint passes
   - [x] test passes on `Ubuntu 22.04`, `python3.11.2`
```
Starting Redis tests
= 2352 passed, 1235 skipped, 849 deselected, 29 xpassed, 347 warnings in 163.65s (0:02:43) =
Waiting for 6 cluster nodes to become available
All nodes are available!
= 1571 passed, 1494 skipped, 1396 deselected, 4 xpassed, 244 warnings in 728.56s (0:12:08) =
```
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested? added tests coverage
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? bugfix only
  - [x] I added some docstring to `redis.asyncio.sentinel` module. I wanted to check if the rST syntax is correct, but this module is not included in the builddir's index, so I think it's no-op. 
- [x] Is there an example added to the examples folder (if applicable)? bugfix only
- [x] Was the change added to CHANGES file? bugfix only

### fix scan iter command issued to different replicas

Fixes #3197